### PR TITLE
chore(workflows): update micromamba version and cache key in pr-tests.yaml

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -50,12 +50,12 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         if: matrix.environment-type == 'miniconda'
         with:
-          micromamba-version: '1.4.5-0'
+          micromamba-version: '1.5.1-2'
           environment-file: environment.yml
           init-shell: >-
             bash
           cache-environment: true
-          cache-environment-key: environment-${{ steps.date.outputs.date }}
+          cache-environment-key: environment-${{ steps.date.outputs.date }}-${{ hashFiles('environment.yml') }}
           cache-downloads-key: downloads-${{ steps.date.outputs.date }}
           post-cleanup: 'all'
 

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -56,7 +56,7 @@ jobs:
             bash
           cache-environment: true
           cache-environment-key: environment-${{ steps.date.outputs.date }}-${{ hashFiles('environment.yml') }}
-          cache-downloads-key: downloads-${{ steps.date.outputs.date }}
+          cache-downloads-key: downloads-${{ steps.date.outputs.date }}-${{ hashFiles('environment.yml') }}
           post-cleanup: 'all'
 
 


### PR DESCRIPTION
- Updated the micromamba version from '1.4.5-0' to '1.5.1-2' in the pr-tests.yaml workflow.
- Modified the cache-environment-key to include a hash of the 'environment.yml' file to ensure cache invalidation when the environment file changes.