### PR TITLE
refactor: change openai api key assignment and model list retrieval

### DIFF
--- a/llamabot/bot/__init__.py
+++ b/llamabot/bot/__init__.py
@@ -3,7 +3,6 @@
 import os
 import warnings
 
-import openai
 import panel as pn
 from dotenv import load_dotenv
 
@@ -26,7 +25,6 @@ if api_key is None:
         "No OpenAI API key found. Please set OPENAI_API_KEY in your environment.",
         category=RuntimeWarning,
     )
-openai.api_key = api_key
 
 
 __all__ = ["SimpleBot", "ChatBot", "QueryBot", "ImageBot"]

--- a/llamabot/bot/imagebot.py
+++ b/llamabot/bot/imagebot.py
@@ -5,6 +5,7 @@ from IPython.display import display, Image
 import requests
 from pathlib import Path
 from typing import Union
+from langchain.schema import AIMessage
 
 
 class ImageBot:
@@ -48,17 +49,7 @@ class ImageBot:
         image_data = requests.get(image_url).content
 
         if not save_path:
-            from llamabot import SimpleBot
-
-            bot = SimpleBot(
-                "You are a helpful filenaming assistant. "
-                "Filenames should use underscores instead of spaces, "
-                "and should be all lowercase. "
-                "Exclude the file extension. "
-                "Give me a compact filename for the following prompt:"
-            )
-            response = bot(prompt)
-            filename = response.message
+            filename = filename_bot(prompt).content
             save_path = Path(f"{filename}.jpg")
         with open(save_path, "wb") as file:
             file.write(image_data)
@@ -75,3 +66,18 @@ def is_running_in_jupyter() -> bool:
         return True
     except NameError:
         return False
+
+
+def filename_bot(image_prompt: str) -> AIMessage:
+    """Generate a filename from an image prompt."""
+    from llamabot import SimpleBot
+
+    bot = SimpleBot(
+        "You are a helpful filenaming assistant. "
+        "Filenames should use underscores instead of spaces, "
+        "and should be all lowercase. "
+        "Exclude the file extension. "
+        "Give me a compact filename for the following prompt:"
+    )
+    response = bot(image_prompt)
+    return response

--- a/llamabot/bot/imagebot.py
+++ b/llamabot/bot/imagebot.py
@@ -69,7 +69,11 @@ def is_running_in_jupyter() -> bool:
 
 
 def filename_bot(image_prompt: str) -> AIMessage:
-    """Generate a filename from an image prompt."""
+    """Generate a filename from an image prompt.
+
+    :param image_prompt: The image prompt to generate a filename from.
+    :return: The filename generated from the image prompt within an AIMessage object.
+    """
     from llamabot import SimpleBot
 
     bot = SimpleBot(

--- a/llamabot/bot/imagebot.py
+++ b/llamabot/bot/imagebot.py
@@ -47,18 +47,18 @@ class ImageBot:
 
         image_data = requests.get(image_url).content
 
-        from llamabot import SimpleBot
-
-        bot = SimpleBot(
-            "You are a helpful filenaming assistant. "
-            "Filenames should use underscores instead of spaces, "
-            "and should be all lowercase. "
-            "Exclude the file extension. "
-            "Give me a compact filename for the following prompt:"
-        )
-        response = bot(prompt)
-        filename = response.message
         if not save_path:
+            from llamabot import SimpleBot
+
+            bot = SimpleBot(
+                "You are a helpful filenaming assistant. "
+                "Filenames should use underscores instead of spaces, "
+                "and should be all lowercase. "
+                "Exclude the file extension. "
+                "Give me a compact filename for the following prompt:"
+            )
+            response = bot(prompt)
+            filename = response.message
             save_path = Path(f"{filename}.jpg")
         with open(save_path, "wb") as file:
             file.write(image_data)

--- a/llamabot/cli/configure.py
+++ b/llamabot/cli/configure.py
@@ -1,10 +1,13 @@
 """LlamaBot configuration."""
-import openai
+from openai import OpenAI
+import os
+
 import typer
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter
-import os
 from .utils import configure_environment_variable
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 app = typer.Typer()
 
@@ -43,9 +46,7 @@ def default_model(model_name=None):
 
     load_dotenv(llamabotrc_path)
 
-    openai.api_key = os.getenv("OPENAI_API_KEY")
-
-    model_list = openai.Model.list()["data"]
+    model_list = client.models.list()["data"]
     available_models = [x["id"] for x in model_list if "gpt" in x["id"]]
     available_models.sort()
 

--- a/tests/prompt_library/test_python_prompt_library.py
+++ b/tests/prompt_library/test_python_prompt_library.py
@@ -9,6 +9,7 @@ from llamabot.prompt_library.python import codebot, docstring, ghostwriter
 
 
 @given(st.text())
+@settings(deadline=None)
 def test_codebot_instance(input_text: str):
     """Test that codebot returns a SimpleBot instance.
 


### PR DESCRIPTION
- Removed direct assignment of OpenAI API key in __init__.py
- Created an OpenAI client in configure.py using the API key from environment variable
- Replaced direct model list retrieval from OpenAI with client's model list method
- Reordered import statements for better organization