### PR TITLE
refactor(llamabot): remove direct environment variable access in OpenAI client initialization

### DIFF
--- a/llamabot/cli/configure.py
+++ b/llamabot/cli/configure.py
@@ -1,13 +1,13 @@
 """LlamaBot configuration."""
 from openai import OpenAI
-import os
 
 import typer
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter
 from .utils import configure_environment_variable
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+client = OpenAI()
 
 app = typer.Typer()
 


### PR DESCRIPTION
This commit removes the direct access to the environment variable for the OpenAI API key in the client initialization.
The OpenAI client is now initialized without any arguments,
which means it will automatically look for the API key in the environment variables
as per the OpenAI library's default behavior.
This makes the code cleaner and more in line with the library's intended usage.