### PR TITLE
Improve-cli-timing

### DIFF
--- a/llamabot/bot/__init__.py
+++ b/llamabot/bot/__init__.py
@@ -1,7 +1,6 @@
 """Bot abstractions that let me quickly build new GPT-based applications."""
 
 
-import panel as pn
 from dotenv import load_dotenv
 
 from llamabot.config import llamabotrc_path
@@ -11,7 +10,6 @@ from .querybot import QueryBot
 from .simplebot import SimpleBot
 from .imagebot import ImageBot
 
-pn.extension()
 load_dotenv()
 
 if llamabotrc_path.exists():

--- a/llamabot/bot/imagebot.py
+++ b/llamabot/bot/imagebot.py
@@ -1,6 +1,5 @@
 """ImageBot module for generating images."""
 
-from openai import OpenAI
 from IPython.display import display, Image
 import requests
 from pathlib import Path
@@ -18,6 +17,8 @@ class ImageBot:
     """
 
     def __init__(self, model="dall-e-3", size="1024x1024", quality="hd", n=1):
+        from openai import OpenAI
+
         self.client = OpenAI()
         self.model = model
         self.size = size

--- a/llamabot/bot/querybot.py
+++ b/llamabot/bot/querybot.py
@@ -3,7 +3,6 @@ import contextvars
 from pathlib import Path
 from typing import Optional
 from dotenv import load_dotenv
-from loguru import logger
 
 from llamabot.config import default_language_model
 from llamabot.bot.simplebot import SimpleBot
@@ -44,11 +43,9 @@ class QueryBot(SimpleBot, ChatUIMixin):
             stream_target=stream_target,
             **kwargs,
         )
-        logger.debug("Initializing LanceDB DocStore...")
         self.lancedb_store = LanceDBDocStore(table_name=slugify(collection_name))
         self.lancedb_store.reset()
         if document_paths:
-            logger.debug("Adding documents to LanceDB DocStore...")
             self.lancedb_store.add_documents(document_paths=document_paths)
 
         self.response_budget = 2_000
@@ -69,7 +66,6 @@ class QueryBot(SimpleBot, ChatUIMixin):
         # )
 
         retreived_messages = set()
-        logger.debug(f"Retrieving {n_results} documents from LanceDB DocStore...")
         retrieved_messages = retreived_messages.union(
             self.lancedb_store.retrieve(query, n_results)
         )

--- a/llamabot/bot/simplebot.py
+++ b/llamabot/bot/simplebot.py
@@ -11,7 +11,6 @@ from llamabot.components.messages import (
 )
 from llamabot.recorder import autorecord
 from llamabot.config import default_language_model
-from litellm import completion
 
 prompt_recorder_var = contextvars.ContextVar("prompt_recorder")
 
@@ -153,6 +152,8 @@ def _make_response(bot: SimpleBot, messages: list[BaseMessage]):
     :param messages: A list of Messages.
     :return: A response object.
     """
+    from litellm import completion
+
     messages_dumped: list[dict] = [m.model_dump() for m in messages]
     completion_kwargs = dict(
         model=bot.model_name,

--- a/llamabot/components/chatui.py
+++ b/llamabot/components/chatui.py
@@ -1,7 +1,6 @@
 """LlamaBot ChatUI that composes with Bots."""
 
 from typing import Callable, Optional
-import panel as pn
 
 
 class ChatUIMixin:
@@ -12,6 +11,8 @@ class ChatUIMixin:
         initial_message: Optional[str] = None,
         callback_function: Optional[Callable] = None,
     ):
+        import panel as pn
+
         self.callback_function = callback_function
         if callback_function is None:
             self.callback_function = lambda ai_message, user, instance: self(ai_message)

--- a/llamabot/components/history.py
+++ b/llamabot/components/history.py
@@ -5,7 +5,6 @@ We can retrieve the last N messages from the database
 or use vector similarity search to identify similar messages to retrieve (RAGHistory).
 """
 from pathlib import Path
-import chromadb
 from hashlib import sha256
 from llamabot.components.messages import (
     BaseMessage,
@@ -48,6 +47,8 @@ class RAGHistory:
         session_name: str,
         db_path: Path = Path.home() / ".llamabot" / "chroma.db",
     ):
+        import chromadb
+
         client = chromadb.PersistentClient(path=str(db_path))
         collection = client.create_collection(session_name, get_or_create=True)
 

--- a/llamabot/recorder.py
+++ b/llamabot/recorder.py
@@ -3,8 +3,6 @@ import contextvars
 from pathlib import Path
 from typing import Optional
 
-import pandas as pd
-import panel as pn
 
 prompt_recorder_var = contextvars.ContextVar("prompt_recorder")
 
@@ -45,6 +43,8 @@ class PromptRecorder:
 
         :return: A string form of the prompts and responses as a dataframe.
         """
+        import pandas as pd
+
         return pd.DataFrame(self.prompts_and_responses).__str__()
 
     def _repr_html_(self):
@@ -59,6 +59,8 @@ class PromptRecorder:
 
         :return: A pandas DataFrame representation of the prompt recorder.
         """
+        import pandas as pd
+
         return pd.DataFrame(self.prompts_and_responses)
 
     def save(self, path: Path):
@@ -78,14 +80,14 @@ class PromptRecorder:
 
         :return: A panel representation of the prompt recorder.
         """
+        import panel as pn
+
         global index
         index = 0
         pn.extension()
 
         next_button = pn.widgets.Button(name=">")
-        next_button
         prev_button = pn.widgets.Button(name="<")
-        prev_button
 
         buttons = pn.Row(prev_button, next_button)
 


### PR DESCRIPTION
- Move `openai.OpenAI` import to `ImageBot` constructor to reduce initial load time.
- Remove unused `loguru.logger` imports and related debug log statements to clean up the codebase.
- Encapsulate `lancedb.embeddings.get_registry` import within `DocstoreEntry` constructor to streamline dependency management.

This commit improves the maintainability and performance of the llamabot project by optimizing import statements and removing unnecessary logging, which can clutter the output and reduce readability. Additionally, by deferring certain imports to their point of use, we reduce the initial load time of the modules, potentially improving the startup time of the bot.