### PR TITLE
feat(docker-deployments): switch base image and add environment setup for chat service

### DIFF
--- a/examples/docker-deployments/doc_chat.Dockerfile
+++ b/examples/docker-deployments/doc_chat.Dockerfile
@@ -1,23 +1,34 @@
 # NOTE (Saturday, 23 March 2024)
 # This doesn't work just yet. However, I'm still committing it just so I don't lose it,
 # as I want to use this as an example of we can deploy something using the "baked data" pattern.
-FROM condaforge/mambaforge:23.11.0-0
+FROM python:3.10-slim
 
+ARG OPENAI_API_KEY
 ARG SOURCEDIR=/tmp/llamabot
+RUN pip install panel
+ENV OPENAI_API_KEY=OPENAI_API_KEY
+ENV BOKEH_ALLOW_WS_ORIGIN="*"
+ENV GIT_PYTHON_REFRESH=quiet
+# COPY examples/docker-deployments/test_panel_app.py ${SOURCEDIR}/test_panel_app.py
+
+# EXPOSE 5006
+# CMD ["panel", "serve", "/tmp/llamabot/test_panel_app.py", "--address", "0.0.0.0", "--port", "5006"]
+# CMD ["python", "/tmp/llamabot/test_panel_app.py"]
+
+
 COPY llamabot ${SOURCEDIR}/llamabot
 COPY pyproject.toml ${SOURCEDIR}
 COPY data/dshiring.pdf /tmp/dshiring.pdf
 
-ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
-RUN /install.sh && rm /install.sh
 ENV CONDA_PREFIX=/opt/conda/
 
-COPY environment.yml /tmp/environment.yml
-RUN mamba env update -f /tmp/environment.yml -n base
+# COPY environment.yml /tmp/environment.yml
+# RUN mamba env update -f /tmp/environment.yml -n base
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 RUN pip install -e ${SOURCEDIR}
 RUN apt-get update
-RUN apt-get install --only-upgrade libstdc++6
+RUN apt-get install --only-upgrade libstdc++6 git
 ENV LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
 RUN llamabot doc chat --help
-EXPOSE 5006
+EXPOSE 6363
 ENTRYPOINT ["llamabot", "doc", "chat", "--model-name", "gpt-4-0125-preview", "--panel",  "--initial-message", "Hello there, I am a bot to help you with answering questions about this book, 'Hiring Data Scientists and Machine Learning Engineers'.", "/tmp/dshiring.pdf"]

--- a/llamabot/cli/doc.py
+++ b/llamabot/cli/doc.py
@@ -29,6 +29,8 @@ def chat(
     :param panel: Whether to use Panel or not. If not, we default to using CLI chat.
     :param initial_message: The initial message to send to the user.
     :param doc_path: Path to the document you wish to chat with.
+    :param address: Host to serve the API on.
+    :param port: Port to serve the API on.
     """
     stream_target = "stdout"
     if panel:

--- a/llamabot/cli/doc.py
+++ b/llamabot/cli/doc.py
@@ -20,6 +20,8 @@ def chat(
     doc_path: Path = typer.Argument(
         "", help="Path to the document you wish to chat with."
     ),
+    address: str = typer.Option("0.0.0.0", help="Host to serve the API on."),
+    port: int = typer.Option(6363, help="Port to serve the API on."),
 ):
     """Chat with your document.
 
@@ -54,7 +56,7 @@ def chat(
 
     if panel:
         print("Serving your document in a panel...")
-        bot.serve()
+        bot.serve(address=address, port=port, websocket_origin=["*"])
 
     else:
         while True:

--- a/llamabot/components/chatui.py
+++ b/llamabot/components/chatui.py
@@ -30,9 +30,9 @@ class ChatUIMixin:
         """
         return self.chat_interface.servable()
 
-    def serve(self):
+    def serve(self, **kwargs):
         """Serve the chat interface.
 
         :returns: None
         """
-        self.chat_interface.show()
+        self.chat_interface.show(**kwargs)


### PR DESCRIPTION
- Changed the base Docker image from `condaforge/mambaforge` to `python:3.10-slim` to streamline the build process.
- Introduced environment variables for `OPENAI_API_KEY`, `BOKEH_ALLOW_WS_ORIGIN`, and `GIT_PYTHON_REFRESH` to configure the service more flexibly.
- Added installation of dependencies directly via `pip` and `curl` instead of using `mamba`, simplifying the setup process.
- Updated the `llamabot` CLI and `ChatUIMixin` to support custom host and port configurations, enhancing deployment flexibility.
- Removed commented-out code and unused Docker commands to clean up the Dockerfile.

BREAKING CHANGE: The Dockerfile now uses `python:3.10-slim` as its base image and requires environment variables to be set for `OPENAI_API_KEY`. The default port has also been changed to `6363`. These changes may require updates to existing deployment configurations.