### PR TITLE
First cut of "llamabot serve" command.

### DIFF
--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -1,0 +1,24 @@
+# Serving a QueryBot: Llamabot CLI Guide
+
+Llamabot CLI introduces the `serve` command, creating an Ollama compatible server
+for your querybot.
+
+#### Usage
+
+Run the command below to start an Ollama compatible server on port 
+
+```bash
+llamabot serve querybot --system-prompt "be smart" --collection-name example --document-paths /path/to/documents.md
+```
+
+Here are the key parameters to understand:
+
+- `--system-prompt`: System prompt.
+- `--collection-name`: Name of the collection.
+- `--document-paths`: Paths to the documents.
+- `--model-name`: AI model to be used for generating responses.
+- `--host`: Host to serve the API on.
+- `--port`: Port to serve the API on.
+
+This creates an Ollama-compatible server so that your QueryBot can be used by any software
+that supports Ollama.

--- a/llamabot/cli/serve.py
+++ b/llamabot/cli/serve.py
@@ -1,13 +1,135 @@
 """Serve up LlamaBots as a FastAPI endpoint."""
-from pathlib import Path
-import typer
-from typing import List
+
 from fastapi import FastAPI
 from llamabot.bot import QueryBot
+from pathlib import Path
+from typing import List, Optional
+import asyncio
+import datetime
+import devtools
+import fastapi
+import json
+import llamabot
+import pydantic
+import time
+import typer
 import uvicorn
 
-api = FastAPI()
+app = FastAPI()
 cli = typer.Typer()
+
+# -------------------------------------------------------------------------------
+# /api/generate
+
+class ApiGenerateRequest(pydantic.BaseModel):
+    model: str
+    prompt: Optional[str] = None
+    images: Optional[List[str]] = None
+    format: Optional[str] = None
+    options: Optional[dict] = None
+    system: Optional[str] = None
+    template: Optional[str] = None
+    context: Optional[str] = None
+    stream: Optional[bool] = True
+    raw: Optional[bool] = False
+
+
+class ApiGenerateResponse(pydantic.BaseModel):
+    # {"model":"llama2","created_at":"2024-01-22T00:01:46.241464Z",
+    #  "response":" of","done":false}
+    model: str
+    created_at: str
+    response: str
+    done: bool
+
+
+class ApiGenerateFinal(pydantic.BaseModel):
+    # {"model":"llama2","created_at":"2024-01-22T00:01:46.332265Z",
+    #  "response":"","done":true,"context":[518,29889],
+    #  "total_duration":4431573792,"load_duration":2964209,
+    #  "prompt_eval_duration":331278000,"eval_count":229,"eval_duration":4089802000
+    # }
+    model: str
+    created_at: str
+    response: str
+    done: bool
+    context: List[int]
+    total_duration: int
+    load_duration: int
+    prompt_eval_count: int
+    prompt_eval_duration: int
+    eval_count: int
+    eval_duration: int
+
+
+@app.post("/api/generate")
+async def api_generate(request: fastapi.Request):
+    """Process /api/generate."""
+    # The ollama API doesn't specify a content type, so we support json and text both.
+    try:
+        data = await request.json()
+    except Exception as e:
+        raise fastapi.HTTPException(status_code=400, detail=f"Invalid JSON: {e}")
+    generate_request = ApiGenerateRequest(**data)
+    devtools.pprint(generate_request)  # TODO: proper logging
+
+    global _the_bot
+
+    # non-streaming
+    if not generate_request.stream:
+        t0 = time.time_ns()
+        t1 = time.time_ns()
+        lines = []
+        for part in _the_bot(generate_request.prompt):
+            lines.append(part)
+        response = "".join(lines)
+        t2 = time.time_ns()
+        return ApiGenerateFinal(
+            model=generate_request.model,
+            created_at=str(datetime.datetime.now().isoformat()),
+            response=response,
+            done=True,
+            context=[0],  # TODO: fill in if possible
+            total_duration=t2 - t0,
+            load_duration=t1 - t0,
+            prompt_eval_count=0,  # TODO: fill in if possible
+            prompt_eval_duration=0,  # TODO: fill in if possible
+            eval_count=0,  # TODO: fill in if possible
+            eval_duration=t2 - t1,
+        )
+
+    # streaming
+    async def stream_api_generate():
+        global _the_bot
+        t0 = time.time_ns()
+        iter = _the_bot(generate_request.prompt)
+        t1 = time.time_ns()
+        for part in iter:
+            yield ApiGenerateResponse(
+                model=generate_request.model,
+                created_at=str(datetime.datetime.now().isoformat()),
+                response=part,
+                done=False,
+            ).json() + "\n"
+        t2 = time.time_ns()
+
+        yield ApiGenerateFinal(
+            model=generate_request.model,
+            created_at=str(datetime.datetime.now().isoformat()),
+            response="",
+            done=True,
+            context=[0],  # TODO: fill in if possible
+            total_duration=t2 - t0,
+            load_duration=t1 - t0,
+            prompt_eval_count=0,  # TODO: fill in if possible
+            prompt_eval_duration=0,  # TODO: fill in if possible
+            eval_count=0,  # TODO: fill in if possible
+            eval_duration=t2 - t1,
+        ).json() + "\n"
+
+    return fastapi.responses.StreamingResponse(
+        stream_api_generate(), media_type="text/json"
+    )
 
 
 @cli.command()
@@ -19,19 +141,25 @@ def querybot(
         "mistral/mistral-medium", help="Name of the model to use."
     ),
     host: str = typer.Option("0.0.0.0", help="Host to serve the API on."),
-    port: int = typer.Option(6363, help="Port to serve the API on."),
+    port: int = typer.Option(32988, help="Port to serve the API on."),
 ):
     """Serve up a LlamaBot as a FastAPI endpoint."""
-    bot = QueryBot(
+    global _the_bot
+
+    # SimpleBot works, QueryBot doesn't seem to return an iterator:
+    #   File "/Users/mark/h/llamabot/llamabot/cli/serve.py", line 107, in stream_api_generate
+    #        for part in iter:
+    #        TypeError: 'NoneType' object is not iterable
+    #_the_bot = QueryBot(
+    #    system_prompt=system_prompt,
+    #    collection_name=collection_name,
+    #    stream_target="api",
+    #    document_paths=document_paths,
+    #    model_name=model_name,
+    #)
+    _the_bot = llamabot.SimpleBot(
         system_prompt=system_prompt,
-        collection_name=collection_name,
-        document_paths=document_paths,
+        stream_target="api",
         model_name=model_name,
     )
-
-    api.add_api_route(
-        "/",
-        bot.create_endpoint(),
-    )
-
-    uvicorn.run(api, host=host, port=port)
+    uvicorn.run(app, host=host, port=port)

--- a/tests/test_serve_nostream.sh
+++ b/tests/test_serve_nostream.sh
@@ -1,0 +1,10 @@
+# generate, stream=false
+# second example from ollama api doc
+
+PORT=${PORT:-32988}
+
+curl -s http://localhost:$PORT/api/generate -d '{
+  "model": "openai/gpt-4",
+  "stream": false,
+  "prompt": "in 10 words or less, why is the sky blue?"
+}'

--- a/tests/test_serve_stream.sh
+++ b/tests/test_serve_stream.sh
@@ -1,0 +1,10 @@
+# generate, stream=false
+# second example from ollama api doc
+
+PORT=${PORT:-32988}
+
+curl -s http://localhost:$PORT/api/generate -d '{
+  "model": "openai/gpt-4",
+  "stream": true,
+  "prompt": "in 10 words or less, why is the sky blue?"
+}'


### PR DESCRIPTION
Currently is working with SimpleBot.

Example usage:
```
llamabot serve querybot --system-prompt "be smart" --collection-name \
junk1 --document-paths ~/h/duckdb-web/docs/sql/query_syntax/where.md
```
I was having problems getting QueryBot to work, but I'll try to get that fixed now.