### PR TITLE
feat(llamabot/cli/docs)📝: Add a new CLI tool for managing Markdown documentation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,10 +11,10 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-# Copy environment.yml (if found) to a temp locaition so we update the environment. Also
-# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
+# Copy lockfile and config file for pixi to install env
 COPY pixi.lock .
 COPY pyproject.toml .
+# Copy docs source, llamabot source, and software tests to get started with development
 COPY docs docs
 COPY llamabot llamabot
 COPY tests tests
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y curl build-essential
 # Configure apt and install packages
 RUN /usr/local/bin/pixi install --manifest-path pyproject.toml
 
-# Install Ollama within Docker container
+# Install Ollama within Docker container to run large language models locally
 RUN curl -fsSL https://ollama.com/install.sh | sh
 
 # Always the final command

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -18,6 +18,13 @@ jobs:
         # Install latest uv version using the installer
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
+      - name: Setup Pixi Environment
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.25.0
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+
       - name: Set up Python
         run: uv python install
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,12 @@ repos:
     rev: v0.0.9
     hooks:
       - id: convert-to-webp
+  - repo: local
+    hooks:
+      - id: pixi-install
+        name: pixi-install
+        entry: pixi install
+        language: system
+        always_run: true
+        require_serial: true
+        pass_filenames: false

--- a/docs/cli/docs.md
+++ b/docs/cli/docs.md
@@ -1,0 +1,74 @@
+---
+intents:
+- Provide reader with a guided tutorial that shows how to use the `llamabot docs write`
+  command at the terminal to generate documentation.
+- Specifically add in information about the `--force` flag.
+- Describe the frontmatter key-value pairs needed to make it work.
+linked_files:
+- llamabot/cli/docs.py
+- pyproject.toml
+---
+
+# LlamaBot Documentation
+
+## Installation
+
+To install LlamaBot, follow these steps:
+
+1. Ensure you have Python 3.10 or higher installed on your system.
+2. Install LlamaBot using pip:
+
+```bash
+pip install llamabot
+```
+
+3. Verify the installation by running:
+
+```bash
+llamabot --help
+```
+
+## Usage
+
+To use LlamaBot to generate documentation, run the following command in the terminal:
+
+```bash
+llamabot docs write <path_to_markdown_file>
+```
+
+### Options
+
+- `--force`: Use this flag to force the documentation update even if it is not detected as out of date.
+
+## Additional Information
+
+For more information, refer to the [official documentation](https://llamabotdocs.com).
+
+## Explanation
+
+To make the `llamabot docs write` command work, ensure that your Markdown source files are properly formatted and located in the correct directory. The command will read the source files, check if the documentation is up-to-date, and update it if necessary. If you use the `--force` flag, the documentation will be updated regardless of its current status.
+
+### Requirements for Target Documentation File
+
+1. **Proper Formatting**: Ensure your Markdown files are correctly formatted.
+2. **Correct Directory**: Place your Markdown files in the appropriate directory as expected by the `llamabot docs write` command.
+3. **Linked Files**: If your documentation references other files, ensure these are correctly linked and accessible.
+
+### Frontmatter Key-Value Pairs
+
+To use the `llamabot docs write` command effectively, your Markdown files should include the following frontmatter:
+
+```markdown
+---
+intents:
+- Point 1 that the documentation should cover.
+- Point 2 that the documentation should cover.
+- ...
+linked_files:
+- path/to/relevant_file1.py
+- path/to/relevant_file2.toml
+- ...
+---
+```
+
+By following these guidelines, you can effectively use LlamaBot to manage and update your documentation.

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -12,7 +12,7 @@ linked_files:
 ---
 # Development Container Overview
 
-The development container for Llamabot is built using a Dockerfile and is influenced by the devcontainer.json file. This document provides an overview of how the dev container is built, the software installed within it, and the build steps with examples of possible common failure modes and how to fix them.
+The development container for Llamabot is built using a Dockerfile and is influenced by the `devcontainer.json` file. This document provides an overview of how the dev container is built, the software installed within it, and the build steps with examples of possible common failure modes and how to fix them.
 
 ## Building the Development Container
 
@@ -22,11 +22,23 @@ The development container is built using the Dockerfile located at `.devcontaine
 
 The Dockerfile includes the following key steps:
 
-1. Copies necessary files and directories into the container.
+1. Copies necessary files and directories into the container, including the `tests` directory and the `llamabot` directory.
 2. Installs `curl` and `build-essential` for C++ (needed for ChromaDB).
 3. Configures apt and installs packages using `pixi` based on the `pyproject.toml` file.
 4. Installs Ollama within the Docker container.
 5. Sets the final command and switches back to dialog for any ad-hoc use of `apt-get`.
+
+### Ollama Software
+
+The 'ollama' software is used to run large language models locally within the Docker container and is installed using the command `RUN curl -fsSL https://ollama.com/install.sh | sh`. Ollama is a crucial component for running large language models within the development container.
+
+### Tests Directory
+
+The `tests` directory contains the software tests to get started with development.
+
+### Llamabot Directory
+
+The 'llamabot' directory contains the source code and documentation for the Llamabot project, highlighting its significance in the development container.
 
 ## Devcontainer.json Influence
 
@@ -38,6 +50,14 @@ The `devcontainer.json` file located at `.devcontainer/devcontainer.json` influe
 - Customizes Visual Studio Code settings and extensions for the development environment.
 - Forwards port 8888 for the development environment.
 - Specifies post-create and post-start commands for setting up the environment and running the Llamabot server.
+
+### Devcontainer.json Commands
+
+The 'postCreateCommand' is used to install pre-commit and set up the Python environment, while the 'postStartCommand' is used to start the 'ollama' server.
+
+### Purpose of postCreateCommand and postStartCommand
+
+The 'postCreateCommand' is executed after the development container is created to set up the environment, and the 'postStartCommand' is executed after the container is started to run the Llamabot server.
 
 ## Build Process
 
@@ -51,7 +71,7 @@ The build process for the development container is automated using GitHub Action
 
 ## Common Failure Modes
 
-Common failure modes in the build process may include issues with Dockerfile syntax, missing dependencies, or failed package installations. These issues can be resolved by carefully reviewing the Dockerfile, ensuring all necessary files are copied, and troubleshooting package installations.
+Common failure modes in the build process may include issues with Dockerfile syntax, missing dependencies, or failed package installations. These issues can be resolved by carefully reviewing the Dockerfile, ensuring all necessary files are copied, and troubleshooting package installations, including the installation process for the 'ollama' software.
 
 ## Conclusion
 

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,0 +1,58 @@
+---
+intents:
+- Provide reader with an overview on how the dev container is built, and what software
+  is installed in dev container.
+- Explain the build steps with examples of possible common failure modes in the build
+  and how to fix them, such that the reader knows how to fix them.
+- Understand how the devcontainer.json file influences the development container.
+linked_files:
+- .github/workflows/build-devcontainer.yaml
+- .devcontainer/Dockerfile
+- .devcontainer/devcontainer.json
+---
+# Development Container Overview
+
+The development container for Llamabot is built using a Dockerfile and is influenced by the devcontainer.json file. This document provides an overview of how the dev container is built, the software installed within it, and the build steps with examples of possible common failure modes and how to fix them.
+
+## Building the Development Container
+
+The development container is built using the Dockerfile located at `.devcontainer/Dockerfile`. The Dockerfile starts with a base image `ghcr.io/prefix-dev/pixi:latest` and sets up the environment by installing necessary software and dependencies. The Dockerfile also adds a non-root user with sudo access and sets up the environment for the development of Llamabot.
+
+### Dockerfile Contents
+
+The Dockerfile includes the following key steps:
+
+1. Copies necessary files and directories into the container.
+2. Installs `curl` and `build-essential` for C++ (needed for ChromaDB).
+3. Configures apt and installs packages using `pixi` based on the `pyproject.toml` file.
+4. Installs Ollama within the Docker container.
+5. Sets the final command and switches back to dialog for any ad-hoc use of `apt-get`.
+
+## Devcontainer.json Influence
+
+The `devcontainer.json` file located at `.devcontainer/devcontainer.json` influences the development container by specifying the build context, customizations for Visual Studio Code, forward ports, and post-create and post-start commands.
+
+### Devcontainer.json Contents
+
+- Specifies the Dockerfile and build context.
+- Customizes Visual Studio Code settings and extensions for the development environment.
+- Forwards port 8888 for the development environment.
+- Specifies post-create and post-start commands for setting up the environment and running the Llamabot server.
+
+## Build Process
+
+The build process for the development container is automated using GitHub Actions. The workflow is defined in the `.github/workflows/build-devcontainer.yaml` file. The workflow is triggered on a schedule and on pushes to the main branch. It sets up QEMU, Docker Buildx, and logs in to Docker Hub. It then builds and pushes the development container to Docker Hub.
+
+### Build Process Workflow
+
+1. Sets up QEMU and Docker Buildx.
+2. Logs in to Docker Hub using secrets.
+3. Builds and pushes the development container to Docker Hub with appropriate tags and caching configurations.
+
+## Common Failure Modes
+
+Common failure modes in the build process may include issues with Dockerfile syntax, missing dependencies, or failed package installations. These issues can be resolved by carefully reviewing the Dockerfile, ensuring all necessary files are copied, and troubleshooting package installations.
+
+## Conclusion
+
+This updated documentation provides an overview of the development container for Llamabot, including the build process, influence of the devcontainer.json file, and common failure modes in the build process. Developers can use this documentation to understand how the development container is built and how to troubleshoot common issues during the build process.

--- a/docs/tutorials/chatbot.md
+++ b/docs/tutorials/chatbot.md
@@ -1,80 +1,55 @@
-# ChatBot Tutorial
+---
+intents:
+- How do we use the llamabot ChatBot class in a Jupyter notebook?
+- How to serve up a Panel app based on that ChatBot class.
+- Specific details on how the ChatBot retrieval works when composing an API call,
+  such as which messages are retrieved from history.
+linked_files:
+- llamabot/bot/chatbot.py
+- llamabot/__init__.py
+---
 
-!!! note
-    This tutorial was written by GPT4 and edited by a human.
+# Using the llamabot ChatBot Class in a Jupyter Notebook
 
-In this tutorial, we will learn how to use the `ChatBot` class to create a simple chatbot that can interact with users. The chatbot is built using the OpenAI GPT-4 model and can be used in a Panel app.
+To use the `ChatBot` class from llamabot in a Jupyter notebook, you can follow these steps:
 
-## Getting Started
-
-First, let's import the `ChatBot` class:
+1. Import the `ChatBot` class from the `llamabot.bot.chatbot` module:
 
 ```python
-from llamabot import ChatBot
+from llamabot.bot.chatbot import ChatBot
 ```
 
-Now, let's create a new instance of the `ChatBot` class. We need to provide a system prompt, which will be used to prime the chatbot. Optionally, we can also set the temperature and model name:
+2. Create an instance of the `ChatBot` class by providing the required parameters such as the system prompt, session name, and any additional configuration options:
 
 ```python
-system_prompt = "Hello, I am a chatbot. How can I help you today?"
-chatbot = ChatBot(system_prompt, temperature=0.0, model_name="gpt-4")
+system_prompt = "Your system prompt here"
+session_name = "Your session name here"
+chatbot = ChatBot(system_prompt, session_name)
 ```
 
-## Interacting with the ChatBot
-
-To interact with the chatbot, we can simply call the chatbot instance with a human message:
+3. Interact with the `ChatBot` instance by calling it with a human message:
 
 ```python
-human_message = "What is the capital of France?"
+human_message = "Hello, how are you?"
 response = chatbot(human_message)
-print(response.content)
+print(response)
 ```
 
-The chatbot will return an `AIMessage` object containing the response to the human message, primed by the system prompt.
+# Serving a Panel App Based on the ChatBot Class
 
-## Chat History
-
-The chatbot automatically manages the chat history. To view the chat history, we can use the `__repr__` method:
+To serve a Panel app based on the `ChatBot` class, you can use the `stream_panel` method of the `ChatBot` class. Here's an example of how to do this:
 
 ```python
-print(chatbot)
+panel_app = chatbot.stream_panel(messages)
+panel_app.servable()
 ```
 
-This will return a string representation of the chat history, with each message prefixed by its type (System, Human, or AI).
+# ChatBot Retrieval and API Composition
 
-## Creating a Panel App
+When composing an API call using the `ChatBot` class, the retrieval of messages from history is handled internally. The `retrieve` method of the `ChatBot` class is used to retrieve messages from the chat history based on the provided human message and response budget. The retrieved messages include the system prompt, historical messages, and the human message itself.
 
-The `ChatBot` class also provides a `panel` method to create a Panel app that wraps the chatbot. This allows users to interact with the chatbot through a web interface.
+For example, when making an API call to the `ChatBot` instance, the retrieval process ensures that the historical context is considered when generating the response.
 
-To create a Panel app, simply call the `panel` method on the chatbot instance:
+This covers the specific details on how the `ChatBot` retrieval works when composing an API call.
 
-```python
-app = chatbot.panel(show=False)
-```
-
-By default, the app will be shown in a new browser window. If you want to return the app directly, set the `show` parameter to `False`.
-
-You can customize the appearance of the app by providing additional parameters, such as `site`, `title`, and `width`:
-
-```python
-app = chatbot.panel(show=False, site="My ChatBot", title="My ChatBot", width=768)
-```
-
-To run the app, you can either call the `show` method on the app or use the Panel `serve` function:
-
-```python
-app.show()
-```
-
-or
-
-```python
-import panel as pn
-pn.serve(app)
-```
-
-Now you have a fully functional chatbot that can interact with users through a web interface!
-
-## Conclusion
-
-In this tutorial, we learned how to use the `ChatBot` class to create a simple chatbot that can interact with users. We also learned how to create a Panel app to provide a web interface for the chatbot. With this knowledge, you can now create your own chatbots and customize them to suit your needs. Happy chatting!
+Please let me know if you need further details or examples.

--- a/docs/tutorials/recording_prompts.md
+++ b/docs/tutorials/recording_prompts.md
@@ -1,7 +1,15 @@
-# Automatically Record QueryBot Calls with PromptRecorder
+---
+intents:
+- This should be a how-to guide that shows a user how the PromptRecorder in LlamaBot
+  works in tandem with QueryBot, specifically using it as a context manager.
+- Specifically, how one sets it up, views recorded prompts and responses, and how
+  to display them in a Panel app.
+linked_files:
+- llamabot/recorder.py
+- llamabot/bot/querybot.py
+---
 
-!!! note
-    This tutorial was written by GPT4 and edited by a human.
+# Automatically Record QueryBot Calls with PromptRecorder
 
 In this tutorial, we will learn how to use the `PromptRecorder` class to automatically record calls made to the `QueryBot`. The `PromptRecorder` class is designed to record prompts and responses, making it a perfect fit for logging interactions with the `QueryBot`.
 
@@ -23,8 +31,8 @@ pip install pandas panel
 First, we need to import the `PromptRecorder` and `QueryBot` classes from their respective source files. You can do this by adding the following lines at the beginning of your script:
 
 ```python
-from prompt_recorder import PromptRecorder, autorecord
-from query_bot import QueryBot
+from llamabot.recorder import PromptRecorder, autorecord
+from llamabot.bot.querybot import QueryBot
 ```
 
 ## Step 2: Initialize the QueryBot
@@ -36,7 +44,7 @@ system_message = "You are a helpful assistant that can answer questions based on
 model_name = "gpt-4"
 doc_paths = ["document1.txt", "document2.txt"]
 
-query_bot = QueryBot(system_message, model_name=model_name, doc_paths=doc_paths)
+query_bot = QueryBot(system_message, model_name=model_name, document_paths=doc_paths)
 ```
 
 ## Step 3: Use the PromptRecorder context manager
@@ -84,14 +92,14 @@ recorder.panel().show()
 Here's the complete example that demonstrates how to use the `PromptRecorder` to automatically record `QueryBot` calls:
 
 ```python
-from prompt_recorder import PromptRecorder, autorecord
-from query_bot import QueryBot
+from llamabot.recorder import PromptRecorder, autorecord
+from llamabot.bot.querybot import QueryBot
 
 system_message = "You are a helpful assistant that can answer questions based on the provided documents."
 model_name = "gpt-4"
 doc_paths = ["document1.txt", "document2.txt"]
 
-query_bot = QueryBot(system_message, model_name=model_name, doc_paths=doc_paths)
+query_bot = QueryBot(system_message, model_name=model_name, document_paths=doc_paths)
 
 with PromptRecorder() as recorder:
     query = "What is the main idea of document1?"

--- a/docs/tutorials/simplebot.md
+++ b/docs/tutorials/simplebot.md
@@ -1,7 +1,20 @@
+---
+intents:
+- Diataxis framework-style tutorial on the usage of SimpleBot.
+- Emphasis on the returned data structures from SimpleBot.__call__(), that these are
+  not strings, but AIMessages.
+- Explanation on what an AIMessage is, showing its class structure.
+- Creating a Panel app to talk with SimpleBot.
+linked_files:
+- llamabot/__init__.py
+- llamabot/bot/simplebot.py
+- llamabot/components/messages.py
+---
+
 # SimpleBot Tutorial
 
 !!! note
-    This tutorial was written by GPT4 and edited by a human.
+This tutorial was written by GPT4 and edited by a human.
 
 In this tutorial, we will learn how to use the `SimpleBot` class, a Python implementation of a chatbot that interacts with OpenAI's GPT-4 model. The `SimpleBot` class is designed to be simple and easy to use, allowing you to create a chatbot that can respond to human messages based on a given system prompt.
 
@@ -10,7 +23,7 @@ In this tutorial, we will learn how to use the `SimpleBot` class, a Python imple
 First, let's import the `SimpleBot` class:
 
 ```python
-from llamabot import SimpleBot
+from llamabot.bot.simplebot import SimpleBot
 ```
 
 ### Initializing the SimpleBot
@@ -32,7 +45,21 @@ response = bot(human_message)
 print(response.content)
 ```
 
-### Using the Panel App
+## AIMessage
+
+When interacting with the `SimpleBot`, it's important to note that the response returned is not a simple string, but an `AIMessage` object. This object contains the generated response and additional metadata. The structure of an `AIMessage` is as follows:
+
+```python
+from llamabot.components.messages import AIMessage
+
+# Example AIMessage structure
+{
+"content": "Generated response content",
+"role": "assistant"
+}
+```
+
+## Using the Panel App
 
 `SimpleBot` also comes with a built-in Panel app that provides a graphical user interface for interacting with the chatbot. To create the app, call the `panel()` method on your `SimpleBot` instance:
 
@@ -53,7 +80,7 @@ app.show()
 Here's a complete example of how to create and interact with a `SimpleBot`:
 
 ```python
-from simple_bot import SimpleBot
+from llamabot.bot.simplebot import SimpleBot
 
 # Initialize the SimpleBot
 system_prompt = "You are an AI assistant that helps users with their questions."
@@ -72,3 +99,7 @@ app.show()
 ## Conclusion
 
 In this tutorial, we learned how to use the `SimpleBot` class to create a simple chatbot that interacts with OpenAI's GPT-4 model. We also learned how to create a Panel app for a more user-friendly interface. With this knowledge, you can now create your own chatbots and experiment with different system prompts and settings.
+
+## Additional Information
+
+For more detailed information on the `SimpleBot` class and its methods, please refer to the source code and documentation provided in the `llamabot` package.

--- a/llamabot/bot/ollama_model_names.txt
+++ b/llamabot/bot/ollama_model_names.txt
@@ -1,3 +1,4 @@
+hermes3
 phi3.5
 smollm
 bge-large

--- a/llamabot/cli/__init__.py
+++ b/llamabot/cli/__init__.py
@@ -8,7 +8,7 @@ import typer
 
 from llamabot import ChatBot, PromptRecorder
 
-from . import blog, configure, doc, git, python, tutorial, zotero, repo, serve
+from . import blog, configure, doc, git, python, tutorial, zotero, repo, serve, docs
 from .utils import exit_if_asked, uniform_prompt
 
 app = typer.Typer()
@@ -41,6 +41,9 @@ app.add_typer(configure.app, name="configure", help="Configure LlamaBot.")
 app.add_typer(repo.app, name="repo", help="Chat with a code repository.")
 app.add_typer(
     serve.cli, name="serve", help="Serve up a LlamaBot as a FastAPI endpoint."
+)
+app.add_typer(
+    docs.app, name="docs", help="Create Markdown documentation from source files."
 )
 
 

--- a/llamabot/cli/docs.py
+++ b/llamabot/cli/docs.py
@@ -1,0 +1,153 @@
+"""CLI for creating and keeping Markdown documentation up-to-date."""
+
+from typer import Typer
+from pathlib import Path
+import frontmatter
+from pydantic import BaseModel, Field
+from llamabot import prompt, StructuredBot, SimpleBot
+import yaml
+from pyprojroot import here
+
+from pydantic import ConfigDict
+
+app = Typer()
+
+
+class MarkdownSourceFile(BaseModel):
+    """Content related to a Markdown source file."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    file_path: Path = Field(..., description="Path to the Markdown source file.")
+    post: frontmatter.Post = Field(..., description="The Markdown content.")
+
+    linked_files: dict[str, str] = Field(
+        {},
+        description="Dictionary mapping linked files to their source texts. These must be relative to the repository root.",
+    )
+    raw_content: str = Field(
+        "", description="The raw content of the Markdown source file."
+    )
+
+    def __init__(self, file_path: Path):
+        super().__init__(file_path=file_path, post=frontmatter.load(file_path))
+
+        for fpath in self.post.get("linked_files", []):
+            with open(here() / fpath, "r+") as f:
+                self.linked_files[fpath] = f.read()
+
+        # self.post.content = "\n".join(f"{i+1}: {line}" for i, line in enumerate(self.post.content.splitlines()))
+        with open(file_path, "r+") as f:
+            # Read in the file contents with line numbers added in.
+            self.raw_content = "".join(
+                f"{i+1}: {line}" for i, line in enumerate(f.readlines())
+            )
+
+
+class DocumentationOutOfDate(BaseModel):
+    """Status indicating whether a documentation is out of date."""
+
+    is_out_of_date: bool = Field(
+        ..., description="Whether the documentation is out of date."
+    )
+
+
+@prompt
+def ood_checker_sysprompt():
+    """You are an expert in documentation management.
+    You will be provided information about a written documentation file,
+    what the documentation is intended to convey,
+    a list of source files that are related to the documentation,
+    and their contents.
+    """
+
+
+@prompt
+def documentation_information(
+    source_file: MarkdownSourceFile, line_numbers: bool = False, issues: dict = {}
+) -> str:
+    """## Intents about the documentation
+
+    Here is the intent about the documentation:
+
+    {% for intent in source_file.post.get("intents", []) %}- {{ intent }}{% endfor %}
+
+    ## Referenced source files
+
+    These are the source files to reference:
+
+    {% for filename, content in source_file.linked_files.items() %}
+    -----
+    [ {{ filename }} ]
+
+    {{ content }}
+    -----
+    {% endfor %}
+
+    ## Issues
+    {% if issues %}
+    Here are additional issues found with the docs:
+
+    {{ issues | safe  }}
+    {% else %}
+    <No issues provided, but there may still be issues.>
+    {% endif %}
+
+    ## Documentation source file
+
+    Finally, here is the documentation source file, {{ source_file.file_path }}:
+
+    -----
+    {% if source_file.post.content %}
+    {% if line_numbers %}
+    {{ source_file.raw_content | safe  }}
+    {% else %}
+    {{ source_file.post.content | safe }}
+    {% endif %}
+    {% else %}
+    <The documentation is empty.>
+    {% endif %}
+    -----
+    """
+
+
+@prompt
+def docwriter_sysprompt():
+    """You are an expert in documentation writing.
+
+    You will be provided a documentation source,
+    a list of what the documentation is intended to cover,
+    and a list of linked source files.
+
+    Based on the issues provided,
+    please edit the documentation to fix those issues,
+    integrating the changes seamelessly into the documentation.
+    Return only the content without any other preamble.
+    """
+
+
+@app.command()
+def write(file_path: Path):
+    """Write the documentation based on the given source file.
+
+    :param file_path: Path to the Markdown source file.
+    """
+    src_file = MarkdownSourceFile(file_path)
+
+    if not src_file.post.content:  # i.e. the documentation is empty
+        docwriter = SimpleBot(system_prompt=docwriter_sysprompt())
+        response = docwriter(documentation_information(src_file))
+
+    else:
+        ood_checker = StructuredBot(
+            system_prompt=ood_checker_sysprompt(), pydantic_model=DocumentationOutOfDate
+        )
+        result = ood_checker(documentation_information(src_file))
+        if result.ood:
+            docwriter = SimpleBot(system_prompt=docwriter_sysprompt())
+            response = docwriter(documentation_information(src_file))
+    with open(src_file, "w+") as f:
+        f.write("---\n")
+        # Write the intents to docs
+        f.write(yaml.dump(src_file.post.metadata))
+        f.write("---\n")
+        f.write(response.content)

--- a/pixi.lock
+++ b/pixi.lock
@@ -286,6 +286,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/2c/94ed7b91db81d61d7096ac8f2d325ec562fc75e35f3baea8749c85b28784/PyPika-0.48.9.tar.gz
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/3e/5a36494314e4780362b15a7e190095eec68366a0d512b5b532607c213a26/pyviz_comms-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/f6/2c80f11a128cf854d6bb90c77976fc60520cd1e1c351c445697b8c35c17b/pyzotero-1.5.20-py3-none-any.whl
@@ -587,6 +588,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/2c/94ed7b91db81d61d7096ac8f2d325ec562fc75e35f3baea8749c85b28784/PyPika-0.48.9.tar.gz
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/3e/5a36494314e4780362b15a7e190095eec68366a0d512b5b532607c213a26/pyviz_comms-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/f6/2c80f11a128cf854d6bb90c77976fc60520cd1e1c351c445697b8c35c17b/pyzotero-1.5.20-py3-none-any.whl
@@ -887,6 +889,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/2c/94ed7b91db81d61d7096ac8f2d325ec562fc75e35f3baea8749c85b28784/PyPika-0.48.9.tar.gz
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/3e/5a36494314e4780362b15a7e190095eec68366a0d512b5b532607c213a26/pyviz_comms-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/f6/2c80f11a128cf854d6bb90c77976fc60520cd1e1c351c445697b8c35c17b/pyzotero-1.5.20-py3-none-any.whl
@@ -1150,6 +1153,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/2c/94ed7b91db81d61d7096ac8f2d325ec562fc75e35f3baea8749c85b28784/PyPika-0.48.9.tar.gz
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/3e/5a36494314e4780362b15a7e190095eec68366a0d512b5b532607c213a26/pyviz_comms-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/f6/2c80f11a128cf854d6bb90c77976fc60520cd1e1c351c445697b8c35c17b/pyzotero-1.5.20-py3-none-any.whl
@@ -1393,6 +1397,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/2c/94ed7b91db81d61d7096ac8f2d325ec562fc75e35f3baea8749c85b28784/PyPika-0.48.9.tar.gz
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/3e/5a36494314e4780362b15a7e190095eec68366a0d512b5b532607c213a26/pyviz_comms-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/f6/2c80f11a128cf854d6bb90c77976fc60520cd1e1c351c445697b8c35c17b/pyzotero-1.5.20-py3-none-any.whl
@@ -1635,6 +1640,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/2c/94ed7b91db81d61d7096ac8f2d325ec562fc75e35f3baea8749c85b28784/PyPika-0.48.9.tar.gz
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/3e/5a36494314e4780362b15a7e190095eec68366a0d512b5b532607c213a26/pyviz_comms-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/f6/2c80f11a128cf854d6bb90c77976fc60520cd1e1c351c445697b8c35c17b/pyzotero-1.5.20-py3-none-any.whl
@@ -1938,6 +1944,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/2c/94ed7b91db81d61d7096ac8f2d325ec562fc75e35f3baea8749c85b28784/PyPika-0.48.9.tar.gz
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/3e/5a36494314e4780362b15a7e190095eec68366a0d512b5b532607c213a26/pyviz_comms-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/f6/2c80f11a128cf854d6bb90c77976fc60520cd1e1c351c445697b8c35c17b/pyzotero-1.5.20-py3-none-any.whl
@@ -2215,6 +2222,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/2c/94ed7b91db81d61d7096ac8f2d325ec562fc75e35f3baea8749c85b28784/PyPika-0.48.9.tar.gz
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/3e/5a36494314e4780362b15a7e190095eec68366a0d512b5b532607c213a26/pyviz_comms-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/f6/2c80f11a128cf854d6bb90c77976fc60520cd1e1c351c445697b8c35c17b/pyzotero-1.5.20-py3-none-any.whl
@@ -2491,6 +2499,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/2c/94ed7b91db81d61d7096ac8f2d325ec562fc75e35f3baea8749c85b28784/PyPika-0.48.9.tar.gz
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/3e/5a36494314e4780362b15a7e190095eec68366a0d512b5b532607c213a26/pyviz_comms-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/f6/2c80f11a128cf854d6bb90c77976fc60520cd1e1c351c445697b8c35c17b/pyzotero-1.5.20-py3-none-any.whl
@@ -6198,7 +6207,7 @@ packages:
   name: llamabot
   version: 0.5.5
   path: .
-  sha256: 48eb39b69931d7d63b17e4bcb0e61899ef3cc5a6f3dfcf63c7d041cfcd990cf0
+  sha256: 567f9e56c13ebf1fdcee2e52d7168b8775d208842118ffb265f9554002a71dc8
   requires_dist:
   - openai
   - panel>=1.3.0
@@ -6230,6 +6239,7 @@ packages:
   - chromadb
   - tantivy
   - numpy<2
+  - python-frontmatter>=1.1.0,<2
   requires_python: '>=3.10'
   editable: true
 - kind: pypi
@@ -8995,6 +9005,20 @@ packages:
   - pkg:pypi/fastjsonschema?source=hash-mapping
   size: 226165
   timestamp: 1718477110630
+- kind: pypi
+  name: python-frontmatter
+  version: 1.1.0
+  url: https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl
+  sha256: 335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1
+  requires_dist:
+  - pyyaml
+  - sphinx ; extra == 'docs'
+  - pytest ; extra == 'test'
+  - toml ; extra == 'test'
+  - pyaml ; extra == 'test'
+  - mypy ; extra == 'test'
+  - types-pyyaml ; extra == 'test'
+  - types-toml ; extra == 'test'
 - kind: conda
   name: python-json-logger
   version: 2.0.7

--- a/pixi.lock
+++ b/pixi.lock
@@ -6207,7 +6207,7 @@ packages:
   name: llamabot
   version: 0.5.5
   path: .
-  sha256: 567f9e56c13ebf1fdcee2e52d7168b8775d208842118ffb265f9554002a71dc8
+  sha256: 4735133db44a555f8b688b83917a15b68361c4db26515131c3a51cdda1f7a953
   requires_dist:
   - openai
   - panel>=1.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ dependencies = [
     "chromadb",
     "tantivy",
     "numpy<2", # https://github.com/ericmjl/llamabot/issues/56
+    "python-frontmatter>=1.1.0,<2",
 ]
 requires-python = ">=3.10"
 description = "A Pythonic interface to LLMs."

--- a/scratch_notebooks/docbot.ipynb
+++ b/scratch_notebooks/docbot.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llamabot import SimpleBot, StructuredBot\n",
+    "import frontmatter\n",
+    "from pyprojroot import here\n",
+    "from llamabot.cli.docs import UnifiedDiff, MarkdownSourceFile, documentation_information, ood_checker_sysprompt, DocumentationIssues"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open up the docs/devcontainer.md file and read YAML header\n",
+    "markdown_source_path = here() / \"docs\" / \"devcontainer.md\"\n",
+    "\n",
+    "src_file = MarkdownSourceFile(markdown_source_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc_checker = StructuredBot(system_prompt=ood_checker_sysprompt(), pydantic_model=DocumentationIssues)\n",
+    "response = doc_checker(documentation_information(src_file, line_numbers=False, issues={}))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For each issue in the response, generate a diff hunk against the text file\n",
+    "from llamabot.cli.docs import docwriter_sysprompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docwriter = SimpleBot(system_prompt=docwriter_sysprompt())\n",
+    "response = docwriter(documentation_information(src_file, line_numbers=False, issues=response.model_dump()))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "with open(markdown_source_path, \"w+\") as f:\n",
+    "    f.write(\"---\\n\")\n",
+    "    # Write the intents to docs\n",
+    "    f.write(yaml.dump(src_file.post.metadata))\n",
+    "    f.write(\"---\\n\")\n",
+    "    f.write(response.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llamabot",
+   "language": "python",
+   "name": "llamabot"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- Create a new file llamabot/cli/docs.py to handle Markdown documentation.
- Implement classes for Markdown source files and documentation status checking.
- Integrate Typer for CLI command handling.
- Use pydantic for validation and frontmatter for Markdown metadata.