### PR TITLE
feat(llamabot/recorder)🔄: Add retry mechanism to sqlite logging function

### DIFF
--- a/llamabot/recorder.py
+++ b/llamabot/recorder.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 from llamabot.components.messages import BaseMessage
 
@@ -260,6 +261,7 @@ def add_column(connection: Connection, table_name: str, column: Column):
 # add_column(engine, PromptResponseLog.__tablename__, Column('new_column_name', String))
 
 
+@retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, min=4, max=10))
 def sqlite_log(obj: Any, messages: list[BaseMessage], db_path: Optional[Path] = None):
     """Log messages to the sqlite database for further analysis.
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -6357,9 +6357,9 @@ packages:
   requires_python: '>=3.8,!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*'
 - kind: pypi
   name: llamabot
-  version: 0.8.5
+  version: 0.8.6
   path: .
-  sha256: 409849ba36572a1eed90c25f2d32c1346a00bec05f2387a46e71eeaab81d2f53
+  sha256: fa5c71f0c693e59c53180fc55e983c6e5eeecdecbd06acc10d136955b433e029
   requires_dist:
   - openai
   - panel
@@ -6398,6 +6398,7 @@ packages:
   - fastapi
   - uvicorn
   - sentence-transformers
+  - tenacity
   - ics ; extra == 'notebooks'
   - tzlocal ; extra == 'notebooks'
   requires_python: <=3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "sentence-transformers",
+    "tenacity",
 ]
 requires-python = "<=3.12"
 description = "A Pythonic interface to LLMs."


### PR DESCRIPTION
- Import retry, stop_after_attempt, wait_exponential from tenacity.
- Apply retry decorator with exponential backoff to the sqlite_log function.

This change introduces a retry mechanism to handle transient errors in database operations more gracefully.

Should resolve #106.