### PR TITLE
refactor(llamabot)🔧: Remove sqlite-vec dependency and related code

### DIFF
--- a/archive/sqlite_vec_docstore.py
+++ b/archive/sqlite_vec_docstore.py
@@ -1,0 +1,137 @@
+"""Archived code for using sqlite-vec as a document store.
+
+We archived this because sqlite-vec is very bleeding-edge.
+It doesn't support arm64 linux.
+As such, it breaks devcontainer (which is based on Linux) builds on Apple Silicon.
+When sqlite-vec supports arm64 linux, we should re-enable this.
+"""
+
+from pathlib import Path
+from typing import List
+
+from sentence_transformers import SentenceTransformer
+
+
+from llamabot.components.docstore import AbstractDocumentStore
+import sqlite3
+
+import sqlite_vec
+
+
+class SQLiteVecDocStore(AbstractDocumentStore):
+    """A document store for LlamaBot that uses sqlite-vec."""
+
+    def __init__(
+        self,
+        db_path: Path = Path.home() / ".llamabot" / "sqlite_vec.db",
+        table_name: str = "documents",
+        embedding_model: str = "all-MiniLM-L6-v2",
+    ):
+        self.db_path = db_path
+        self.table_name = table_name
+        self.embedding_model = SentenceTransformer(embedding_model)
+        self.vector_dim = self.embedding_model.get_sentence_embedding_dimension()
+
+        self.db = sqlite3.connect(str(db_path))
+        self.db.enable_load_extension(True)
+        sqlite_vec.load(self.db)
+        self.db.enable_load_extension(False)
+
+        self._create_table()
+
+    def _create_table(self):
+        """Create the necessary tables."""
+        # Create the documents table
+        self.db.execute(
+            f"""
+        CREATE TABLE IF NOT EXISTS {self.table_name} (
+            id INTEGER PRIMARY KEY,
+            document TEXT
+        )
+        """
+        )
+
+        # Create the vectors virtual table with vec_ prefix
+        self.db.execute(
+            f"""
+        CREATE VIRTUAL TABLE IF NOT EXISTS vec_{self.table_name}
+        USING vec0(embedding float[{self.vector_dim}])
+        """
+        )
+        self.db.commit()
+
+    def _embed(self, text: str) -> bytes:
+        """Create embedding for text."""
+        import struct
+
+        embedding = self.embedding_model.encode(text)
+        return struct.pack(f"{len(embedding)}f", *embedding)
+
+    def append(self, document: str):
+        """Append a document to the store."""
+        # Insert the document and get its ID
+        cursor = self.db.cursor()
+        cursor.execute(
+            f"INSERT INTO {self.table_name} (document) VALUES (?)", (document,)
+        )
+        doc_id = cursor.lastrowid
+
+        # Create and insert the embedding
+        embedding = self._embed(document)
+        cursor.execute(
+            f"INSERT INTO vec_{self.table_name} (rowid, embedding) VALUES (?, ?)",
+            (doc_id, embedding),
+        )
+
+        self.db.commit()
+
+    def extend(self, documents: List[str]):
+        """Extend a list of documents to the store."""
+        for document in documents:
+            self.append(document)
+
+    def retrieve(self, query: str, n_results: int = 10) -> List[str]:
+        """Retrieve documents from the store."""
+        query_embedding = self._embed(query)
+
+        # First get the matching vector IDs
+        vector_matches = self.db.execute(
+            f"""
+            SELECT
+                rowid,
+                distance
+            FROM vec_{self.table_name}
+            WHERE embedding MATCH ?
+            ORDER BY distance
+            LIMIT ?
+            """,
+            [query_embedding, n_results],
+        ).fetchall()
+
+        # Then get the corresponding documents
+        if vector_matches:
+            vector_ids = [match[0] for match in vector_matches]
+            placeholders = ",".join("?" * len(vector_ids))
+            documents = self.db.execute(
+                f"""
+                SELECT document
+                FROM {self.table_name}
+                WHERE id IN ({placeholders})
+                """,
+                vector_ids,
+            ).fetchall()
+
+            return [doc[0] for doc in documents]
+        return []
+
+    def reset(self):
+        """Reset the document store."""
+        self.db.execute(f"DROP TABLE IF EXISTS {self.table_name}")
+        self.db.execute(f"DROP TABLE IF EXISTS vec_{self.table_name}")
+        self.db.commit()
+        self._create_table()
+
+    def __post_add_documents__(self):
+        """Execute code after adding documents to the store."""
+        # No additional indexing needed for sqlite-vec
+        pass

--- a/llamabot/bot/ollama_model_names.txt
+++ b/llamabot/bot/ollama_model_names.txt
@@ -1,3 +1,5 @@
+smollm2
+granite3-guardian
 aya-expanse
 granite3-moe
 granite3-dense

--- a/llamabot/components/docstore.py
+++ b/llamabot/components/docstore.py
@@ -12,15 +12,11 @@ Hence we use it by default.
 
 from hashlib import sha256
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable
 
 from tqdm.auto import tqdm
 
 from llamabot.doc_processor import magic_load_doc, split_document
-
-import sqlite3
-from sentence_transformers import SentenceTransformer
-import sqlite_vec
 
 
 class AbstractDocumentStore:
@@ -297,122 +293,3 @@ class BM25DocStore(AbstractDocumentStore):
     def reset(self):
         """Reset the document store."""
         self.documents = []
-
-
-class SQLiteVecDocStore(AbstractDocumentStore):
-    """A document store for LlamaBot that uses sqlite-vec."""
-
-    def __init__(
-        self,
-        db_path: Path = Path.home() / ".llamabot" / "sqlite_vec.db",
-        table_name: str = "documents",
-        embedding_model: str = "all-MiniLM-L6-v2",
-    ):
-        self.db_path = db_path
-        self.table_name = table_name
-        self.embedding_model = SentenceTransformer(embedding_model)
-        self.vector_dim = self.embedding_model.get_sentence_embedding_dimension()
-
-        self.db = sqlite3.connect(str(db_path))
-        self.db.enable_load_extension(True)
-        sqlite_vec.load(self.db)
-        self.db.enable_load_extension(False)
-
-        self._create_table()
-
-    def _create_table(self):
-        """Create the necessary tables."""
-        # Create the documents table
-        self.db.execute(
-            f"""
-        CREATE TABLE IF NOT EXISTS {self.table_name} (
-            id INTEGER PRIMARY KEY,
-            document TEXT
-        )
-        """
-        )
-
-        # Create the vectors virtual table with vec_ prefix
-        self.db.execute(
-            f"""
-        CREATE VIRTUAL TABLE IF NOT EXISTS vec_{self.table_name}
-        USING vec0(embedding float[{self.vector_dim}])
-        """
-        )
-        self.db.commit()
-
-    def _embed(self, text: str) -> bytes:
-        """Create embedding for text."""
-        import struct
-
-        embedding = self.embedding_model.encode(text)
-        return struct.pack(f"{len(embedding)}f", *embedding)
-
-    def append(self, document: str):
-        """Append a document to the store."""
-        # Insert the document and get its ID
-        cursor = self.db.cursor()
-        cursor.execute(
-            f"INSERT INTO {self.table_name} (document) VALUES (?)", (document,)
-        )
-        doc_id = cursor.lastrowid
-
-        # Create and insert the embedding
-        embedding = self._embed(document)
-        cursor.execute(
-            f"INSERT INTO vec_{self.table_name} (rowid, embedding) VALUES (?, ?)",
-            (doc_id, embedding),
-        )
-
-        self.db.commit()
-
-    def extend(self, documents: List[str]):
-        """Extend a list of documents to the store."""
-        for document in documents:
-            self.append(document)
-
-    def retrieve(self, query: str, n_results: int = 10) -> List[str]:
-        """Retrieve documents from the store."""
-        query_embedding = self._embed(query)
-
-        # First get the matching vector IDs
-        vector_matches = self.db.execute(
-            f"""
-            SELECT
-                rowid,
-                distance
-            FROM vec_{self.table_name}
-            WHERE embedding MATCH ?
-            ORDER BY distance
-            LIMIT ?
-            """,
-            [query_embedding, n_results],
-        ).fetchall()
-
-        # Then get the corresponding documents
-        if vector_matches:
-            vector_ids = [match[0] for match in vector_matches]
-            placeholders = ",".join("?" * len(vector_ids))
-            documents = self.db.execute(
-                f"""
-                SELECT document
-                FROM {self.table_name}
-                WHERE id IN ({placeholders})
-                """,
-                vector_ids,
-            ).fetchall()
-
-            return [doc[0] for doc in documents]
-        return []
-
-    def reset(self):
-        """Reset the document store."""
-        self.db.execute(f"DROP TABLE IF EXISTS {self.table_name}")
-        self.db.execute(f"DROP TABLE IF EXISTS vec_{self.table_name}")
-        self.db.commit()
-        self._create_table()
-
-    def __post_add_documents__(self):
-        """Execute code after adding documents to the store."""
-        # No additional indexing needed for sqlite-vec
-        pass

--- a/pixi.lock
+++ b/pixi.lock
@@ -310,7 +310,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/00/59/f6551f49c123751e921038c24215157bd50aef375ced16cac57229678c43/sh-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/ab/81d4514527c068670cb1d7ab62a81a185df53a7c379bd2a5636e83d09ede/SQLAlchemy-2.0.36-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/c3/ba/c405b77ad31c00ea3ffe932a3e0b0f3b1da3bbc22068fd4f3c76b517abd0/sqlite_vec-0.1.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/cc/b8f7faf35403b9ed5fd349a15cc8637ae3ce75983272fecc32f07b9dbe47/tantivy-0.22.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -620,7 +619,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/00/59/f6551f49c123751e921038c24215157bd50aef375ced16cac57229678c43/sh-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/bf/005dc47f0e57556e14512d5542f3f183b94fde46e15ff1588ec58ca89555/SQLAlchemy-2.0.36-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b1/55/5fe3efe8c38eb1e8aa53ea11fabc581519203a8d4f001f217f0c134d43c3/sqlite_vec-0.1.3-py3-none-macosx_10_6_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/ff/c87e0622b1dadea79d2fb0b25ade9ed98954c9033722eb707053d310d4f3/sympy-1.13.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/2b/a361cc7228663f6fa14a82de6568bc728c8c2c212ca979d17482ea7cdffd/tantivy-0.22.0-cp312-cp312-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl
@@ -928,7 +926,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/00/59/f6551f49c123751e921038c24215157bd50aef375ced16cac57229678c43/sh-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/65/f109d5720779a08e6e324ec89a744f5f92c48bd8005edc814bf72fbb24e5/SQLAlchemy-2.0.36-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/92/21/f0052d87ec413db6a161642183447b2dea296770d7f214d8e7fcc54dfa90/sqlite_vec-0.1.3-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/2b/a361cc7228663f6fa14a82de6568bc728c8c2c212ca979d17482ea7cdffd/tantivy-0.22.0-cp312-cp312-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl
@@ -1204,7 +1201,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/ab/81d4514527c068670cb1d7ab62a81a185df53a7c379bd2a5636e83d09ede/SQLAlchemy-2.0.36-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/c3/ba/c405b77ad31c00ea3ffe932a3e0b0f3b1da3bbc22068fd4f3c76b517abd0/sqlite_vec-0.1.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl
@@ -1455,7 +1451,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/bf/005dc47f0e57556e14512d5542f3f183b94fde46e15ff1588ec58ca89555/SQLAlchemy-2.0.36-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b1/55/5fe3efe8c38eb1e8aa53ea11fabc581519203a8d4f001f217f0c134d43c3/sqlite_vec-0.1.3-py3-none-macosx_10_6_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/ff/c87e0622b1dadea79d2fb0b25ade9ed98954c9033722eb707053d310d4f3/sympy-1.13.3-py3-none-any.whl
@@ -1704,7 +1699,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/65/f109d5720779a08e6e324ec89a744f5f92c48bd8005edc814bf72fbb24e5/SQLAlchemy-2.0.36-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/92/21/f0052d87ec413db6a161642183447b2dea296770d7f214d8e7fcc54dfa90/sqlite_vec-0.1.3-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl
@@ -2014,7 +2008,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/a5/10f97f73544edcdef54409f1d839f6049a0d79df68adbc1ceb24d1aaca42/smmap-5.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/ab/81d4514527c068670cb1d7ab62a81a185df53a7c379bd2a5636e83d09ede/SQLAlchemy-2.0.36-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/c3/ba/c405b77ad31c00ea3ffe932a3e0b0f3b1da3bbc22068fd4f3c76b517abd0/sqlite_vec-0.1.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/cc/b8f7faf35403b9ed5fd349a15cc8637ae3ce75983272fecc32f07b9dbe47/tantivy-0.22.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -2297,7 +2290,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/a5/10f97f73544edcdef54409f1d839f6049a0d79df68adbc1ceb24d1aaca42/smmap-5.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/bf/005dc47f0e57556e14512d5542f3f183b94fde46e15ff1588ec58ca89555/SQLAlchemy-2.0.36-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b1/55/5fe3efe8c38eb1e8aa53ea11fabc581519203a8d4f001f217f0c134d43c3/sqlite_vec-0.1.3-py3-none-macosx_10_6_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/ff/c87e0622b1dadea79d2fb0b25ade9ed98954c9033722eb707053d310d4f3/sympy-1.13.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/2b/a361cc7228663f6fa14a82de6568bc728c8c2c212ca979d17482ea7cdffd/tantivy-0.22.0-cp312-cp312-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl
@@ -2578,7 +2570,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/a5/10f97f73544edcdef54409f1d839f6049a0d79df68adbc1ceb24d1aaca42/smmap-5.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/65/f109d5720779a08e6e324ec89a744f5f92c48bd8005edc814bf72fbb24e5/SQLAlchemy-2.0.36-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/92/21/f0052d87ec413db6a161642183447b2dea296770d7f214d8e7fcc54dfa90/sqlite_vec-0.1.3-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/2b/a361cc7228663f6fa14a82de6568bc728c8c2c212ca979d17482ea7cdffd/tantivy-0.22.0-cp312-cp312-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl
@@ -6390,7 +6381,7 @@ packages:
   name: llamabot
   version: 0.9.12
   path: .
-  sha256: bddbfe742b13a53db01391d6fe66df1c4df3195edd118fdcf52e53a96047806b
+  sha256: 70774db4ef14c795462cc8c0d43dd0fb415927fe78a009234a3fd7a15bac5bf1
   requires_dist:
   - openai
   - panel
@@ -6430,7 +6421,6 @@ packages:
   - uvicorn
   - sentence-transformers
   - tenacity
-  - sqlite-vec>=0.1.3,<0.2
   - ics ; extra == 'notebooks'
   - tzlocal ; extra == 'notebooks'
   requires_python: <3.13
@@ -10431,21 +10421,6 @@ packages:
   - pymysql ; extra == 'pymysql'
   - sqlcipher3-binary ; extra == 'sqlcipher'
   requires_python: '>=3.7'
-- kind: pypi
-  name: sqlite-vec
-  version: 0.1.3
-  url: https://files.pythonhosted.org/packages/92/21/f0052d87ec413db6a161642183447b2dea296770d7f214d8e7fcc54dfa90/sqlite_vec-0.1.3-py3-none-macosx_11_0_arm64.whl
-  sha256: c55ca8661444c4e669f6bf61cd1b985765f6f702b1df6da78f58ad7ee7297947
-- kind: pypi
-  name: sqlite-vec
-  version: 0.1.3
-  url: https://files.pythonhosted.org/packages/b1/55/5fe3efe8c38eb1e8aa53ea11fabc581519203a8d4f001f217f0c134d43c3/sqlite_vec-0.1.3-py3-none-macosx_10_6_x86_64.whl
-  sha256: 965a503cbad515d3f75f3cb43e18589a89ad793f16d96ba9328db6dfd86469f0
-- kind: pypi
-  name: sqlite-vec
-  version: 0.1.3
-  url: https://files.pythonhosted.org/packages/c3/ba/c405b77ad31c00ea3ffe932a3e0b0f3b1da3bbc22068fd4f3c76b517abd0/sqlite_vec-0.1.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl
-  sha256: 440233ddedd617b3cd64766bdd1858ee8fec7c6f6a4582da222ac37e4de587c7
 - kind: pypi
   name: stack-data
   version: 0.6.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "sentence-transformers",
-    "tenacity", "sqlite-vec>=0.1.3,<0.2",
+    "tenacity",
 ]
 requires-python = "<3.13"
 description = "A Pythonic interface to LLMs."


### PR DESCRIPTION
- Removed sqlite-vec from dependencies in pyproject.toml and pixi.lock.
- Deleted SQLiteVecDocStore class from docstore.py due to lack of support for arm64 Linux.
- Archived sqlite_vec_docstore.py with explanation for future re-enablement.