### PR TITLE
refactor(llamabot/components)🔧: Refactor type hinting and update llamabot version

### DIFF
--- a/llamabot/components/messages.py
+++ b/llamabot/components/messages.py
@@ -160,7 +160,7 @@ def retrieve_messages_up_to_budget(
 
 
 def process_messages(
-    messages: tuple[Union[str, BaseMessage, list[Union[str, BaseMessage]], ...]]
+    messages: tuple[Union[str, BaseMessage, list[Union[str, BaseMessage]]], ...]
 ) -> list[BaseMessage]:
     """Process a tuple of messages into a list of BaseMessage objects.
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -10952,9 +10952,9 @@ packages:
   requires_python: '!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8'
 - kind: pypi
   name: llamabot
-  version: 0.9.21
+  version: 0.10.0
   path: .
-  sha256: 130d093d816de838ef8cec5425db01513ce0040160290714e9f120d6e4e84be9
+  sha256: fae125e4270f39a4f3bc026c256ea22637bc92a9a6b89f22f9586dd1eaa41a85
   requires_dist:
   - openai
   - panel

--- a/tests/components/test_messages.py
+++ b/tests/components/test_messages.py
@@ -5,6 +5,7 @@ from llamabot.components.messages import (
     HumanMessage,
     AIMessage,
     ToolMessage,
+    process_messages,
 )
 
 
@@ -42,3 +43,30 @@ def test_tool_message_slicing():
     assert msg[5:].content == "Output"
     assert msg[-6:].content == "Output"
     assert msg[:-7].content == "Tool"
+
+
+def test_process_messages_with_nested_types():
+    """Test that process_messages handles various input types correctly."""
+    from llamabot.components.messages import (
+        HumanMessage,
+        SystemMessage,
+    )
+
+    # Test with a mix of types
+    test_message = SystemMessage(content="system message")
+    messages = (
+        "human message",
+        test_message,
+        ["nested message 1", "nested message 2"],
+    )
+
+    result = process_messages(messages)
+
+    assert len(result) == 4
+    assert isinstance(result[0], HumanMessage)
+    assert result[0].content == "human message"
+    assert result[1] == test_message
+    assert isinstance(result[2], HumanMessage)
+    assert result[2].content == "nested message 1"
+    assert isinstance(result[3], HumanMessage)
+    assert result[3].content == "nested message 2"


### PR DESCRIPTION
- Correct the type hinting in process_messages function to include ellipsis for variable length tuples.
- Update llamabot version from 0.9.21 to 0.10.0 in pixi.lock.
- Add process_messages to the import in test_messages.py to ensure it is available for testing.
- Extend test_process_messages_with_nested_types to verify handling of various input types.