### PR TITLE
fix(llamabot/components)🔧: Update FTS index creation and llamabot version

### DIFF
--- a/llamabot/components/docstore.py
+++ b/llamabot/components/docstore.py
@@ -195,7 +195,7 @@ class LanceDBDocStore(AbstractDocumentStore):
             ]
         except ValueError:
             self.existing_records = []
-        self.table.create_fts_index(field_names=["document"])
+        self.table.create_fts_index(field_names=["document"], replace=True)
 
     def __contains__(self, other: str) -> bool:
         """Returns boolean whether the 'other' document is in the store.

--- a/pixi.lock
+++ b/pixi.lock
@@ -10952,9 +10952,9 @@ packages:
   requires_python: '!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8'
 - kind: pypi
   name: llamabot
-  version: 0.10.0
+  version: 0.10.1
   path: .
-  sha256: fae125e4270f39a4f3bc026c256ea22637bc92a9a6b89f22f9586dd1eaa41a85
+  sha256: 5d503273283cde9c1b6e264e7832371796c215e115d20d52573e4ea01e2b7217
   requires_dist:
   - openai
   - panel


### PR DESCRIPTION
- Enable replacement of existing FTS index in LanceDBDocStore.
- Update llamabot version from 0.10.0 to 0.10.1 in pixi.lock.