### PR TITLE
fix(structuredbot)🐛: Handle special case for ollama_chat model in StructuredBot

### DIFF
--- a/llamabot/bot/structuredbot.py
+++ b/llamabot/bot/structuredbot.py
@@ -57,13 +57,16 @@ class StructuredBot(SimpleBot):
         **completion_kwargs,
     ):
         params = get_supported_openai_params(model=model_name)
-        if not (
+        # Special case for ollama_chat - it supports structured outputs
+        if "ollama_chat" in model_name:
+            pass  # Ollama chat supports structured outputs
+        elif not (
             "response_format" in params and supports_response_schema(model=model_name)
         ):
             raise ValueError(
                 f"Model {model_name} does not support structured responses. "
                 "Please use a model that supports both `response_format` and `response_schema`; "
-                "`gpt-4o`, `anthropic/claude-3-5-sonnet`, "
+                "`gpt-4`, `anthropic/claude-3-5-sonnet`, "
                 "and gemini/gemini-1.5-pro-latest are specific examples, "
                 "just make sure you have the appropriate API key for the model."
             )

--- a/pixi.lock
+++ b/pixi.lock
@@ -9563,7 +9563,7 @@ packages:
 - pypi: .
   name: llamabot
   version: 0.10.11
-  sha256: 768442ca5d8a25b74ad8ccb7b0df7f29889ff31e498f4a26da9a558da1c9feea
+  sha256: 412d6cee3f226c2bfea17144635423b50cf82818aa198a6b9eb0cefd47e8c860
   requires_dist:
   - openai
   - panel
@@ -9585,7 +9585,7 @@ packages:
   - sh
   - pre-commit
   - beartype
-  - litellm
+  - litellm>=1.59.1
   - python-slugify
   - pydantic>=2.0
   - pdfminer-six

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
     "sh",
     "pre-commit",
     "beartype",
-    "litellm",
+    "litellm>=1.59.1", # this is necessary to guarantee that ollama_chat models are supported for structured outputs
     "python-slugify",
     "pydantic>=2.0",
     "pdfminer.six",

--- a/tests/bot/test_structuredbot.py
+++ b/tests/bot/test_structuredbot.py
@@ -74,3 +74,15 @@ def test_structuredbot_unsupported_model():
 
     assert "does not support structured responses" in str(exc_info.value)
     assert "mistral-medium" in str(exc_info.value)
+
+
+def test_ollama_chat_model_initialization():
+    """Test that ollama chat models can be initialized without raising an error."""
+    system_prompt = SystemMessage(content="Test prompt")
+    # Should not raise an error
+    bot = StructuredBot(
+        system_prompt=system_prompt,
+        pydantic_model=TestModel,
+        model_name="ollama_chat/gemma2:2b",
+    )
+    assert bot.model_name == "ollama_chat/gemma2:2b"


### PR DESCRIPTION
- Added a condition to bypass checks for ollama_chat models as they support structured outputs.
- Updated the error message to include gpt-4 as a supported model.
- Added a test case to ensure ollama_chat models initialize correctly without errors.