### PR TITLE
refactor(slugify usage)🔧: Refactor slugify usage to ensure consistent naming conventions.

### DIFF
--- a/llamabot/bot/querybot.py
+++ b/llamabot/bot/querybot.py
@@ -14,7 +14,6 @@ from llamabot.components.chatui import ChatUIMixin
 from llamabot.components.messages import (
     RetrievedMessage,
 )
-from slugify import slugify
 
 load_dotenv()
 
@@ -79,8 +78,6 @@ class QueryBot(SimpleBot, ChatUIMixin):
             stream_target=stream_target,
             **kwargs,
         )
-
-        collection_name = slugify(collection_name, separator="_")
 
         if docstore_path:
             docstore_kwargs["storage_path"] = docstore_path

--- a/llamabot/components/docstore.py
+++ b/llamabot/components/docstore.py
@@ -14,6 +14,7 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Callable, Optional
 
+import slugify
 from tqdm.auto import tqdm
 
 from llamabot.doc_processor import magic_load_doc, split_document
@@ -100,6 +101,8 @@ class ChromaDBDocStore(AbstractDocumentStore):
                 "ChromaDB is required for ChromaDBDocStore. "
                 "Please `pip install llamabot[rag]` to use the ChromaDB document store."
             )
+
+        collection_name = slugify.slugify(collection_name, separator="-")
 
         client = chromadb.PersistentClient(path=str(storage_path))
         collection = client.create_collection(collection_name, get_or_create=True)
@@ -235,6 +238,8 @@ class LanceDBDocStore(AbstractDocumentStore):
 
             document: str = func.SourceField()
             vector: Vector(func.ndims()) = func.VectorField()
+
+        table_name = slugify.slugify(table_name, separator="-")
 
         self.schema = DocstoreEntry
         self.table_name = table_name


### PR DESCRIPTION
- Removed slugify usage from QueryBot class as it was unnecessary.
- Added slugify usage in ChromaDBDocStore and LanceDBDocStore classes for consistent naming.