### PR TITLE
refactor(agentbot)🤖: Add respond_to_user tool and improve tool call handling in AgentBot

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -26,6 +26,13 @@ Editing:
 - Don't worry about linting errors. I have automatic linting tools.
 - If I ask you to diagnose a problem, do not jump into editing. Present the diagnosis, and wait for me to confirm whether I want to apply the fix, as I may sometimes disagree with the diagnosis.
 
+Templates and UI:
+
+- When implementing UI components that appear in multiple places, use template includes or macros to ensure consistency.
+- If a UI component (like message expansion) appears in multiple templates, extract it into a shared partial template.
+- Always verify that UI behavior is consistent across all instances of the same component.
+- When adding new features to UI components, ensure they are added to all relevant templates.
+
 Notebooks:
 
 - If I ask you to generate a Marimo notebook, it generally looks like this:

--- a/.cursorrules
+++ b/.cursorrules
@@ -28,10 +28,16 @@ Editing:
 
 Templates and UI:
 
-- When implementing UI components that appear in multiple places, use template includes or macros to ensure consistency.
-- If a UI component (like message expansion) appears in multiple templates, extract it into a shared partial template.
-- Always verify that UI behavior is consistent across all instances of the same component.
-- When adding new features to UI components, ensure they are added to all relevant templates.
+- Use Jinja2 macros (defined in macros.html) for any UI component that appears in multiple templates.
+- When creating a new UI component that might be reused:
+  1. Create a macro in macros.html with clear parameter documentation
+  2. Use the macro in all templates that need the component
+  3. Ensure the macro preserves HTMX attributes and functionality
+- Never duplicate UI component code across templates - always use macros for shared components.
+- When adding features to a UI component:
+  1. Update the macro in macros.html
+  2. All templates using the macro will automatically get the new feature
+- Keep macros focused and single-purpose - if a macro grows too complex, consider breaking it into smaller macros.
 
 Notebooks:
 

--- a/llamabot/web/static/styles.css
+++ b/llamabot/web/static/styles.css
@@ -459,3 +459,31 @@ pre code {
     font-family: monospace;
     white-space: pre-wrap;
 }
+
+.tool-calls {
+    background-color: #f8f9fa;
+    border-radius: 4px;
+    padding: 10px;
+    margin-top: 10px;
+}
+
+.tool-calls h6 {
+    color: #6c757d;
+    margin-bottom: 8px;
+}
+
+.tool-call {
+    background-color: #fff;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    padding: 8px;
+    margin-bottom: 8px;
+}
+
+.tool-call:last-child {
+    margin-bottom: 0;
+}
+
+.tool-call strong {
+    color: #495057;
+}

--- a/llamabot/web/templates/log_details.html
+++ b/llamabot/web/templates/log_details.html
@@ -53,6 +53,19 @@
                     </div>
                     <div class="collapse {{ 'show' if expanded else '' }}" id="message-{{ loop.index }}">
                         <div class="content">{{ message.content }}</div>
+                        {% if message.tool_calls %}
+                            <div class="tool-calls mt-2">
+                                <h6>Tool Calls:</h6>
+                                <div class="tool-calls-list">
+                                    {% for tool_call in message.tool_calls %}
+                                        <div class="tool-call">
+                                            <strong>Function:</strong> {{ tool_call.function.name }}<br>
+                                            <strong>Arguments:</strong> {{ tool_call.function.arguments }}
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        {% endif %}
                     </div>
                 </div>
             {% endfor %}

--- a/llamabot/web/templates/log_details.html
+++ b/llamabot/web/templates/log_details.html
@@ -1,3 +1,5 @@
+{% from "macros.html" import message_expansion %}
+
 <div class="card">
     <div class="card-body">
         <h5 class="card-title">Log Details</h5>
@@ -29,45 +31,7 @@
 
         <div class="message-log" id="message-log-{{ log.id }}">
             {% for message in log.message_log %}
-                <div class="message {% if message.role == 'assistant' %}assistant{% elif message.role == 'system' %}system{% else %}user{% endif %}">
-                    <div class="message-header">
-                        <div class="role"
-                             role="button"
-                             data-bs-toggle="collapse"
-                             data-bs-target="#message-{{ loop.index }}"
-                             aria-expanded="{{ 'true' if expanded else 'false' }}">
-                            <i class="collapse-icon">▼</i> {{ message.role }}
-                        </div>
-                        {% if message.prompt_name %}
-                            <div class="prompt-info">
-                                <span class="prompt-name">{{ message.prompt_name }}</span>
-                                <a href="#" class="prompt-hash"
-                                   hx-get="/prompts/{{ message.prompt_hash }}"
-                                   hx-target="#modal-content"
-                                   hx-trigger="click"
-                                   hx-swap="innerHTML">
-                                    {{ message.prompt_hash[:8] }}...
-                                </a>
-                            </div>
-                        {% endif %}
-                    </div>
-                    <div class="collapse {{ 'show' if expanded else '' }}" id="message-{{ loop.index }}">
-                        <div class="content">{{ message.content }}</div>
-                        {% if message.tool_calls %}
-                            <div class="tool-calls mt-2">
-                                <h6>Tool Calls:</h6>
-                                <div class="tool-calls-list">
-                                    {% for tool_call in message.tool_calls %}
-                                        <div class="tool-call">
-                                            <strong>Function:</strong> {{ tool_call.function.name }}<br>
-                                            <strong>Arguments:</strong> {{ tool_call.function.arguments }}
-                                        </div>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                        {% endif %}
-                    </div>
-                </div>
+                {{ message_expansion(message, loop.index, expanded) }}
             {% endfor %}
         </div>
     </div>

--- a/llamabot/web/templates/macros.html
+++ b/llamabot/web/templates/macros.html
@@ -1,0 +1,41 @@
+{% macro message_expansion(message, loop_index, expanded=false) %}
+<div class="message {% if message.role == 'assistant' %}assistant{% elif message.role == 'system' %}system{% else %}user{% endif %}">
+    <div class="message-header">
+        <div class="role"
+             role="button"
+             data-bs-toggle="collapse"
+             data-bs-target="#message-{{ loop_index }}"
+             aria-expanded="{{ 'true' if expanded else 'false' }}">
+            <i class="collapse-icon">▼</i> {{ message.role }}
+        </div>
+        {% if message.prompt_name %}
+            <div class="prompt-info">
+                <span class="prompt-name">{{ message.prompt_name }}</span>
+                <a href="#" class="prompt-hash"
+                   hx-get="/prompts/{{ message.prompt_hash }}"
+                   hx-target="#modal-content"
+                   hx-trigger="click"
+                   hx-swap="innerHTML">
+                    {{ message.prompt_hash[:8] }}...
+                </a>
+            </div>
+        {% endif %}
+    </div>
+    <div class="collapse {{ 'show' if expanded else '' }}" id="message-{{ loop_index }}">
+        <div class="content">{{ message.content }}</div>
+        {% if message.tool_calls %}
+            <div class="tool-calls mt-2">
+                <h6>Tool Calls:</h6>
+                <div class="tool-calls-list">
+                    {% for tool_call in message.tool_calls %}
+                        <div class="tool-call">
+                            <strong>Function:</strong> {{ tool_call.function.name }}<br>
+                            <strong>Arguments:</strong> {{ tool_call.function.arguments }}
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endmacro %}

--- a/llamabot/web/templates/message_log.html
+++ b/llamabot/web/templates/message_log.html
@@ -1,41 +1,7 @@
-{% for message in log.message_log %}
-    <div class="message {% if message.role == 'assistant' %}assistant{% elif message.role == 'system' %}system{% else %}user{% endif %}">
-        <div class="message-header">
-            <div class="role"
-                 role="button"
-                 data-bs-toggle="collapse"
-                 data-bs-target="#message-{{ loop.index }}"
-                 aria-expanded="{{ 'true' if expanded else 'false' }}">
-                <i class="collapse-icon">▼</i> {{ message.role }}
-            </div>
-            {% if message.prompt_name %}
-                <div class="prompt-info">
-                    <span class="prompt-name">{{ message.prompt_name }}</span>
-                    <a href="#" class="prompt-hash"
-                       hx-get="/prompts/{{ message.prompt_hash }}"
-                       hx-target="#modal-content"
-                       hx-trigger="click"
-                       hx-swap="innerHTML">
-                        {{ message.prompt_hash[:8] }}...
-                    </a>
-                </div>
-            {% endif %}
-        </div>
-        <div class="collapse {{ 'show' if expanded else '' }}" id="message-{{ loop.index }}">
-            <div class="content">{{ message.content }}</div>
-            {% if message.tool_calls %}
-                <div class="tool-calls mt-2">
-                    <h6>Tool Calls:</h6>
-                    <div class="tool-calls-list">
-                        {% for tool_call in message.tool_calls %}
-                            <div class="tool-call">
-                                <strong>Function:</strong> {{ tool_call.function.name }}<br>
-                                <strong>Arguments:</strong> {{ tool_call.function.arguments }}
-                            </div>
-                        {% endfor %}
-                    </div>
-                </div>
-            {% endif %}
-        </div>
-    </div>
-{% endfor %}
+{% from "macros.html" import message_expansion %}
+
+<div class="message-log" id="message-log-{{ log.id }}">
+    {% for message in log.message_log %}
+        {{ message_expansion(message, loop.index, expanded) }}
+    {% endfor %}
+</div>

--- a/llamabot/web/templates/message_log.html
+++ b/llamabot/web/templates/message_log.html
@@ -23,6 +23,19 @@
         </div>
         <div class="collapse {{ 'show' if expanded else '' }}" id="message-{{ loop.index }}">
             <div class="content">{{ message.content }}</div>
+            {% if message.tool_calls %}
+                <div class="tool-calls mt-2">
+                    <h6>Tool Calls:</h6>
+                    <div class="tool-calls-list">
+                        {% for tool_call in message.tool_calls %}
+                            <div class="tool-call">
+                                <strong>Function:</strong> {{ tool_call.function.name }}<br>
+                                <strong>Arguments:</strong> {{ tool_call.function.arguments }}
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
         </div>
     </div>
 {% endfor %}


### PR DESCRIPTION
- Include respond_to_user tool in default and custom tool lists for AgentBot.
- Update system prompt to instruct using respond_to_user only when confident in the response.
- Initialize futures dictionary before ThreadPoolExecutor usage.
- Simplify tool call result handling by removing exception catching and always logging completion.
- Change message appended after tool calls from AIMessage to HumanMessage and add prompt for next step decision.