### PR TITLE
docs(README)📚: Update README to replace ChatBot with SimpleBot for chat functionality and improve QueryBot usage instructions

### DIFF
--- a/llamabot/bot/ollama_model_names.txt
+++ b/llamabot/bot/ollama_model_names.txt
@@ -1,4 +1,5 @@
 mistral-small3.2
+gemma3n
 magistral
 devstral
 qwen2.5vl


### PR DESCRIPTION
- Replace ChatBot with SimpleBot and LanceDBDocStore for chat with memory example
- Clarify QueryBot usage with docstore creation and loading existing docstore
- Remove ChatBot references from cache configuration section
- Add new Ollama model name 'gemma3n' to the list