### PR TITLE
feat: add SpanList for unified span visualization and auto input/output logging

### DIFF
--- a/llamabot/__init__.py
+++ b/llamabot/__init__.py
@@ -26,20 +26,21 @@ from .bot.querybot import QueryBot
 from .bot.simplebot import SimpleBot
 from .bot.structuredbot import StructuredBot
 from .bot.toolbot import ToolBot
+from .components.chat_memory import ChatMemory
+from .components.docstore import BM25DocStore, LanceDBDocStore
+from .components.messages import dev, system, user
+from .components.pocketflow import nodeify
+from .components.tools import tool
 from .experiments import Experiment, metric
 from .prompt_manager import prompt
-from .components.messages import user, system, dev
-from .components.tools import tool
-from .components.docstore import BM25DocStore, LanceDBDocStore
-from .components.chat_memory import ChatMemory
-from .components.pocketflow import nodeify
 from .recorder import (
-    span,
-    get_current_span,
-    get_spans,
-    get_span_tree,
-    enable_span_recording,
+    SpanList,
     dict_to_span,
+    enable_span_recording,
+    get_current_span,
+    get_span_tree,
+    get_spans,
+    span,
 )
 
 
@@ -94,6 +95,7 @@ __all__ = [
     "get_span_tree",
     "enable_span_recording",
     "dict_to_span",
+    "SpanList",
 ]
 
 # Ensure ~/.llamabot directory exists

--- a/llamabot/bot/agentbot.py
+++ b/llamabot/bot/agentbot.py
@@ -277,19 +277,28 @@ class AgentBot:
 
         :return: HTML string for displaying spans in marimo notebooks
         """
-        from llamabot.recorder import build_hierarchy, generate_span_html, get_spans
+        from llamabot.recorder import (
+            build_hierarchy,
+            generate_span_html,
+            get_spans,
+            span_to_dict,
+        )
 
         if not self._trace_ids:
             return '<div style="padding: 1rem; color: #2E3440;">No spans recorded for this bot instance yet.</div>'
 
         # Collect all spans from all trace_ids for this bot instance
-        all_spans = []
+        all_spans_objects = []
         for trace_id in self._trace_ids:
             spans = get_spans(trace_id=trace_id)
-            all_spans.extend(spans)
+            # SpanList is iterable, so we can extend with it
+            all_spans_objects.extend(spans)
 
-        if not all_spans:
+        if not all_spans_objects:
             return '<div style="padding: 1rem; color: #2E3440;">No spans found in database for this bot instance.</div>'
+
+        # Convert Span objects to dictionaries for visualization
+        all_spans = [span_to_dict(s) for s in all_spans_objects]
 
         # Find root spans (spans with no parent) to use as current span
         # Use the most recent root span (last one in the list)

--- a/llamabot/bot/simplebot.py
+++ b/llamabot/bot/simplebot.py
@@ -32,6 +32,7 @@ from llamabot.recorder import (
     generate_span_html,
     get_spans,
     is_span_recording_enabled,
+    span_to_dict,
     sqlite_log,
 )
 
@@ -292,13 +293,17 @@ class SimpleBot:
             return '<div style="padding: 1rem; color: #2E3440;">No spans recorded for this bot instance yet.</div>'
 
         # Collect all spans from all trace_ids for this bot instance
-        all_spans = []
+        all_spans_objects = []
         for trace_id in self._trace_ids:
             spans = get_spans(trace_id=trace_id)
-            all_spans.extend(spans)
+            # SpanList is iterable, so we can extend with it
+            all_spans_objects.extend(spans)
 
-        if not all_spans:
+        if not all_spans_objects:
             return '<div style="padding: 1rem; color: #2E3440;">No spans found in database for this bot instance.</div>'
+
+        # Convert Span objects to dictionaries for visualization
+        all_spans = [span_to_dict(s) for s in all_spans_objects]
 
         # Find root spans (spans with no parent) to use as current span
         # Use the most recent root span (last one in the list)

--- a/notebooks/span_logging_example.py
+++ b/notebooks/span_logging_example.py
@@ -42,13 +42,12 @@ def _():
 
     from llamabot import (
         SimpleBot,
-        dict_to_span,
         enable_span_recording,
         get_spans,
         span,
     )
 
-    return SimpleBot, dict_to_span, enable_span_recording, get_spans, mo, span
+    return SimpleBot, enable_span_recording, get_spans, mo, span
 
 
 @app.cell(hide_code=True)
@@ -185,11 +184,11 @@ def _(mo):
 
 
 @app.cell
-def _(dict_to_span, get_spans):
+def _(get_spans):
+    # get_spans() returns a SpanList that displays all spans together
     all_spans = get_spans()
-    # Display the first span if available
-    first_span = dict_to_span(all_spans[0]) if all_spans else None
-    first_span
+    # Display all spans in unified visualization
+    all_spans
     return (all_spans,)
 
 
@@ -269,6 +268,7 @@ def _(mo):
 @app.cell
 def _(get_spans):
     filtered_spans = get_spans(user_id=123)
+    filtered_spans
     return (filtered_spans,)
 
 
@@ -279,6 +279,13 @@ def _(filtered_spans, mo):
     Found {len(filtered_spans)} spans with user_id=123
     """
     )
+    return
+
+
+@app.cell
+def _(get_spans):
+    gemma_spans = get_spans(model="ollama_chat/gemma3n:latest")
+    gemma_spans
     return
 
 
@@ -354,10 +361,26 @@ def _(get_spans):
 
 
 @app.cell
-def _(decorated_spans, dict_to_span):
-    # Display the first decorated span
-    decorated_span = dict_to_span(decorated_spans[0]) if decorated_spans else None
-    decorated_span
+def _(decorated_spans):
+    # Display all decorated spans together
+    decorated_spans
+    return
+
+
+@app.cell
+def _(span):
+    # This time without any arguments
+    @span
+    def explodify(s: str, i: int) -> str:
+        return f"{'!' * i} {s} {'!' * i}"
+
+    explodify("Boom!", 3)
+    return
+
+
+@app.cell
+def _(get_spans):
+    get_spans(operation_name="explodify")
     return
 
 
@@ -388,10 +411,9 @@ def _(get_spans):
 
 
 @app.cell
-def _(category_spans, dict_to_span):
-    # Display the first category span
-    category_span = dict_to_span(category_spans[0]) if category_spans else None
-    category_span
+def _(category_spans):
+    # Display all category spans together
+    category_spans
     return
 
 

--- a/tests/bot/test_simplebot.py
+++ b/tests/bot/test_simplebot.py
@@ -594,9 +594,9 @@ def test_bot_tracks_multiple_trace_ids(tmp_path, monkeypatch):
         spans = get_spans(trace_id=trace_id, db_path=db_path)
         assert len(spans) > 0
         # Each call should have a simplebot_call root span
-        root_spans = [s for s in spans if s.get("parent_span_id") is None]
+        root_spans = [s for s in spans if s.parent_span_id is None]
         assert len(root_spans) == 1
-        assert root_spans[0]["operation_name"] == "simplebot_call"
+        assert root_spans[0].operation_name == "simplebot_call"
 
 
 def test_bot_display_spans_shows_all_calls(tmp_path, monkeypatch):
@@ -627,8 +627,8 @@ def test_bot_display_spans_shows_all_calls(tmp_path, monkeypatch):
         all_spans.extend(spans)
 
     # Verify HTML contains references to spans from all calls
-    for span_dict in all_spans:
-        assert span_dict["span_id"] in html or span_dict["operation_name"] in html
+    for span_obj in all_spans:
+        assert span_obj.span_id in html or span_obj.operation_name in html
 
 
 def test_bot_spans_exclude_manual_spans(tmp_path, monkeypatch):
@@ -665,8 +665,8 @@ def test_bot_spans_exclude_manual_spans(tmp_path, monkeypatch):
         all_bot_spans.extend(spans)
 
     manual_spans = get_spans(trace_id=manual_span.trace_id, db_path=db_path)
-    bot_span_ids = {s["span_id"] for s in all_bot_spans}
-    manual_span_ids = {s["span_id"] for s in manual_spans}
+    bot_span_ids = {s.span_id for s in all_bot_spans}
+    manual_span_ids = {s.span_id for s in manual_spans}
 
     # No overlap between bot spans and manual spans
     assert bot_span_ids.isdisjoint(manual_span_ids)
@@ -727,8 +727,8 @@ def test_bot_creates_new_trace_id_even_with_existing_context(tmp_path, monkeypat
     bot_spans = get_spans(trace_id=bot_trace_id, db_path=db_path)
     manual_spans = get_spans(trace_id=manual_trace_id, db_path=db_path)
 
-    bot_span_ids = {s["span_id"] for s in bot_spans}
-    manual_span_ids = {s["span_id"] for s in manual_spans}
+    bot_span_ids = {s.span_id for s in bot_spans}
+    manual_span_ids = {s.span_id for s in manual_spans}
 
     # No overlap between bot spans and manual spans
     assert bot_span_ids.isdisjoint(
@@ -787,8 +787,8 @@ def test_trace_id_cleared_after_root_span_exit(tmp_path, monkeypatch):
     # Verify spans are in separate traces (no overlap)
     bot_spans = get_spans(trace_id=bot_trace_id, db_path=db_path)
     manual_spans = get_spans(trace_id=manual_span.trace_id, db_path=db_path)
-    bot_span_ids = {s["span_id"] for s in bot_spans}
-    manual_span_ids = {s["span_id"] for s in manual_spans}
+    bot_span_ids = {s.span_id for s in bot_spans}
+    manual_span_ids = {s.span_id for s in manual_spans}
     assert bot_span_ids.isdisjoint(manual_span_ids)
 
 
@@ -810,11 +810,11 @@ def test_nested_spans_preserve_trace_id(tmp_path, monkeypatch):
     # Verify all spans from bot call share the same trace_id
     bot_spans = get_spans(trace_id=bot_trace_id, db_path=db_path)
     assert len(bot_spans) > 0
-    for span_dict in bot_spans:
-        assert span_dict["trace_id"] == bot_trace_id
+    for span_obj in bot_spans:
+        assert span_obj.trace_id == bot_trace_id
 
     # Verify nested spans (like llm_request, llm_response) are included
-    operation_names = {s["operation_name"] for s in bot_spans}
+    operation_names = {s.operation_name for s in bot_spans}
     assert "simplebot_call" in operation_names
     assert "llm_request" in operation_names
     assert "llm_response" in operation_names


### PR DESCRIPTION
## Summary

This PR adds two major features to the span logging system:

### 1. SpanList Class for Unified Visualization
- Created `SpanList` class that wraps spans and provides unified HTML visualization
- `get_spans()` now returns `SpanList` instead of `List[Span]`
- `SpanList` handles multiple root spans from different traces in a single view
- When displayed in a marimo notebook, all spans are shown together automatically
- Provides list-like behavior (`__iter__`, `__getitem__`, `__len__`, slicing, etc.)
- Includes helper methods: `.filter()` and `.group_by_trace()`

### 2. Automatic Input/Output Logging
- `@span` decorator now automatically logs function inputs and outputs
- Inputs are logged as `input_{param_name}` attributes (coerced to strings)
- Output is logged as `output` attribute (coerced to string)
- Handles unstringifiable objects gracefully with fallback messages
- Works with `*args` and `**kwargs` functions

## Changes
- `llamabot/recorder.py`: Added `SpanList` class and updated `get_spans()` and `_span_decorator()`
- `llamabot/bot/simplebot.py`: Updated to work with `SpanList`
- `llamabot/bot/agentbot.py`: Updated to work with `SpanList`
- `llamabot/__init__.py`: Exported `SpanList`
- `notebooks/span_logging_example.py`: Updated to use `SpanList` display
- `tests/test_recorder.py`: Added tests for automatic input/output logging
- `tests/bot/test_simplebot.py`: Updated tests to work with `SpanList`

## Testing
All tests pass. Added comprehensive tests for:
- Basic input/output logging with named parameters
- Functions with `*args` and `**kwargs`
- Handling of unstringifiable objects