### PR TITLE
fix: improve error message when @prompt decorator is used without parentheses

### DIFF
--- a/llamabot/prompt_manager.py
+++ b/llamabot/prompt_manager.py
@@ -104,10 +104,41 @@ def version_prompt(
 class prompt:
     """Wrap a Python function into a Jinja2-templated prompt with version control.
 
-    :param role: The role of the prompt.
+    :param role: The role of the prompt. Must be one of "system", "user", or "assistant".
+
+    Usage::
+
+        @prompt("user")
+        def my_prompt(code: str) -> str:
+            '''Analyze this code: {{ code }}'''
+
+    Note: The decorator must always be called with a role argument.
+    Using @prompt without parentheses (i.e., @prompt instead of @prompt("system"))
+    is not supported.
     """
 
     def __init__(self, role: Literal["system", "user", "assistant"] = "system"):
+        # Check if the decorator was used without parentheses (i.e., @prompt instead of @prompt("system"))
+        # In that case, `role` will be the decorated function, not a string
+        if callable(role):
+            raise TypeError(
+                "The @prompt decorator must be called with a role argument.\n\n"
+                "Incorrect usage:\n"
+                "    @prompt\n"
+                "    def my_prompt(...):\n"
+                "        ...\n\n"
+                "Correct usage:\n"
+                "    @prompt('user')  # or 'system' or 'assistant'\n"
+                "    def my_prompt(...):\n"
+                "        ..."
+            )
+
+        valid_roles = ("system", "user", "assistant")
+        if role not in valid_roles:
+            raise ValueError(
+                f"Invalid role '{role}'. Must be one of: {', '.join(valid_roles)}"
+            )
+
         self.role = role
 
     def __call__(self, func: Callable) -> Callable:

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -208,6 +208,44 @@ def test_version_prompt_error_handling(db_session, monkeypatch):
         version_prompt("Test template", "test_function")
 
 
+def test_prompt_without_parentheses_raises_error():
+    """Test that using @prompt without parentheses raises a clear error.
+
+    When the decorator is used as @prompt instead of @prompt("role"),
+    it should raise a TypeError with a helpful message.
+    """
+    with pytest.raises(TypeError) as exc_info:
+
+        @prompt
+        def test_func():
+            """This is a test function."""
+
+    error_message = str(exc_info.value)
+    assert "must be called with a role argument" in error_message
+    assert "@prompt('user')" in error_message
+    assert "Incorrect usage" in error_message
+    assert "Correct usage" in error_message
+
+
+def test_prompt_with_invalid_role_raises_error():
+    """Test that using @prompt with an invalid role raises a clear error.
+
+    When the decorator is used with a role that is not 'system', 'user',
+    or 'assistant', it should raise a ValueError.
+    """
+    with pytest.raises(ValueError) as exc_info:
+
+        @prompt("invalid_role")
+        def test_func():
+            """This is a test function."""
+
+    error_message = str(exc_info.value)
+    assert "Invalid role 'invalid_role'" in error_message
+    assert "system" in error_message
+    assert "user" in error_message
+    assert "assistant" in error_message
+
+
 def test_user_message_with_string():
     """Test that user() correctly creates a HumanMessage from a string.
 


### PR DESCRIPTION
## Summary

- Adds clear error message when `@prompt` decorator is used without parentheses (e.g., `@prompt` instead of `@prompt("user")`)
- Adds validation for invalid role values with helpful error message

## Problem

Previously, using `@prompt` without parentheses would result in a cryptic error:

```
TypeError: descriptor '__call__' for 'type' objects doesn't apply to a 'str' object
```

## Solution

Now it raises a clear `TypeError` with usage examples:

```
TypeError: The @prompt decorator must be called with a role argument.

Incorrect usage:
    @prompt
    def my_prompt(...):
        ...

Correct usage:
    @prompt('user')  # or 'system' or 'assistant'
    def my_prompt(...):
        ...
```