### PR TITLE
docs: per-bot design LLDs and EARS (SimpleBot, StructuredBot, ToolBot, QueryBot)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,8 @@ For substantial features, follow the **design-driven-dev** skill (`.agents/skill
 - **`docs/designs/<feature>/LLD.md`** — low-level design per feature
 - **`docs/designs/<feature>/<subfeature>-EARS.md`** — testable requirements (EARS IDs, status markers)
 
+Bot classes use **one folder per bot** under `docs/designs/` (e.g. `simplebot/`, `structuredbot/`, `toolbot/`, `querybot/`, `agentbot/`), each with an LLD and EARS file(s).
+
 **Cross-links**: HLD → LLDs; each LLD → HLD and its EARS files; each EARS → parent LLD. **Bug fixes** usually skip new docs but should **verify intent coherence** with existing specs.
 
 Topic notes that predate this layout remain under **`docs/design/`**; new work should prefer **`docs/designs/<feature>/`** when adding a full HLD/LLD/EARS chain.

--- a/docs/designs/agentbot/LLD.md
+++ b/docs/designs/agentbot/LLD.md
@@ -97,6 +97,8 @@ Returns the **string name** of the next tool; `prep_res["func_call"]` holds pars
 
 ## Dependencies
 
+- **SimpleBot LLD**: [Shared completion stack](../simplebot/LLD.md).
+- **ToolBot LLD**: [`ToolBot` / `AsyncToolBot`](../toolbot/LLD.md) contracts used by `DecideNode`.
 - **PocketFlow**: graph execution.
 - **LiteLLM**: completions via `SimpleBot` / `ToolBot` / `AsyncToolBot` / other async bots.
 - **`DEFAULT_TOOLS`**: baseline tools (e.g. `respond_to_user`) for the reference graph.

--- a/docs/designs/querybot/LLD.md
+++ b/docs/designs/querybot/LLD.md
@@ -1,0 +1,63 @@
+# QueryBot and AsyncQueryBot — Low-Level Design
+
+**Created**: 2026-03-28
+
+**Last updated**: 2026-03-28
+
+**HLD Link**: [../../high-level-design.md](../../high-level-design.md)
+
+## Requirements (EARS)
+
+- [querybot-EARS.md](./querybot-EARS.md) — RAG composition, retrieval spans, logging, async behavior.
+
+## Overview
+
+`QueryBot` answers a user query using **retrieval-augmented generation**: it pulls chunks from a required **`AbstractDocumentStore`** (`docstore`), optionally pulls additional chunks from a second store passed as **`memory`**, then completes with LiteLLM via the same **`completion_kwargs_for_messages`** path as `SimpleBot`. It **does not** use `SimpleBot.compose_messages_for_human_messages` or the default “single user turn + optional memory retrieve” flow from `SimpleBot.__call__`; it replaces the call path with **`compose_rag_messages`** and **`QueryBot.__call__`**.
+
+## Inheritance and modules
+
+| Class | Module | Base |
+| ----- | ------ | ---- |
+| `QueryBot` | `llamabot.bot.querybot` | `SimpleBot` |
+| `AsyncQueryBot` | `llamabot.bot.querybot` | `QueryBot` |
+
+## Data and dependencies
+
+| Field | Type | Role |
+| ----- | ---- | ---- |
+| `docstore` | `AbstractDocumentStore` | Primary retrieval corpus; **required**. |
+| `memory` | `Optional[AbstractDocumentStore]` | Optional second retrieval source; also receives **`append`** of assistant text after each successful call when set. |
+
+`SimpleBot.__init__` is invoked **without** wiring `memory` from the `QueryBot` constructor; `QueryBot` assigns `self.memory` after `super().__init__`, reusing the attribute name for the optional second store.
+
+## RAG message composition
+
+`compose_rag_messages(query, n_results, outer_span)`:
+
+1. Resolves `query_content` from `str`, `HumanMessage`, or `BaseMessage`.
+2. Starts `messages` with `system_prompt`.
+3. Under a nested span **`retrieval`**: `docstore.retrieve(query_content, n_results)`; each chunk becomes `RetrievedMessage(content=chunk)`; span records document counts.
+4. If `memory` is set: under span **`memory_retrieval`**, `memory.retrieve(query_content, n_results)` with the same pattern; span records counts.
+5. Appends **`HumanMessage(content=query_content)`**.
+6. Sets outer span `query` / `temperature` metadata.
+7. Returns `(messages, processed_messages)` where **`processed_messages = to_basemessage(messages)`** for the LiteLLM call, and **`messages`** is the list used for **`sqlite_log`** (see below).
+
+## Completion and logging
+
+- **`QueryBot.__call__`**: Outer **Span** (same pattern as other bots), `compose_rag_messages`, then **`make_response(self, processed_messages, stream)`** and **`stream_chunks`**, then **`extract_tool_calls`** / **`extract_content`** → **`AIMessage`**. **`sqlite_log(self, messages + [response_message])`** uses the **pre-`to_basemessage`** `messages` list (system + retrieved + human). If `memory` is set, **`memory.append(response_message.content)`** (assistant string only).
+
+- **`AsyncQueryBot.__call__`**: Runs **`super().__call__`** in **`asyncio.to_thread`** with the same `query` and `n_results`.
+
+- **`AsyncQueryBot.stream_async`**: Same spans and `compose_rag_messages`, then **`stream_tokens_for_messages(self, processed_messages, finalize=...)`** with a `finalize` that logs and appends to `memory` like sync.
+
+## Traceability (intent → code)
+
+| EARS ID | Code |
+| ------- | ---- |
+| `QRY-RAG-*` | `llamabot/bot/querybot.py` |
+
+## Related Documents
+
+- [High-Level Design](../../high-level-design.md)
+- [SimpleBot LLD](../simplebot/LLD.md) — shared LiteLLM helpers (`make_response`, `stream_chunks`, `stream_tokens_for_messages`, `completion_kwargs_for_messages`).
+- [QueryBot EARS](./querybot-EARS.md)

--- a/docs/designs/querybot/querybot-EARS.md
+++ b/docs/designs/querybot/querybot-EARS.md
@@ -1,0 +1,43 @@
+# QueryBot and AsyncQueryBot — EARS
+
+**Parent LLD**: [./LLD.md](./LLD.md)
+
+## Construction
+
+- [x] **QRY-RAG-001**: The system shall provide `QueryBot` with a required `docstore` of type `AbstractDocumentStore` and an optional `memory` of the same abstract type.
+
+- [x] **QRY-RAG-002**: After `SimpleBot.__init__`, the system shall set `self.memory` from the `QueryBot` constructor argument (optional second document store), independent of `SimpleBot`’s default `memory` parameter.
+
+## Retrieval and message order
+
+- [x] **QRY-RAG-010**: `compose_rag_messages` shall call `docstore.retrieve(query_content, n_results)` and wrap each returned chunk in `RetrievedMessage`.
+
+- [x] **QRY-RAG-011**: Where `memory` is set, the system shall call `memory.retrieve(query_content, n_results)` and wrap each chunk in `RetrievedMessage` after docstore chunks and before the final user `HumanMessage`.
+
+- [x] **QRY-RAG-012**: The final message in the composed list before `to_basemessage` shall be `HumanMessage` with content equal to the query string.
+
+- [x] **QRY-RAG-013**: The system shall record nested spans `retrieval` and, when applicable, `memory_retrieval`, with result counts on the spans and outer span.
+
+## Completion and persistence
+
+- [x] **QRY-RAG-020**: `QueryBot.__call__` shall pass `processed_messages` from `compose_rag_messages` to `make_response` / `stream_chunks`, and shall pass `messages + [response_message]` to `sqlite_log`.
+
+- [x] **QRY-RAG-021**: Where `memory` is set, `QueryBot.__call__` shall call `memory.append` with the assistant message **content string** after logging.
+
+## AsyncQueryBot
+
+- [x] **QRY-RAG-030**: `AsyncQueryBot.__call__` shall delegate to `QueryBot.__call__` via `asyncio.to_thread` with the same `query` and `n_results`.
+
+- [x] **QRY-RAG-031**: `AsyncQueryBot.stream_async` shall use `compose_rag_messages` then `stream_tokens_for_messages` with `processed_messages`, and the `finalize` callback shall log the turn and append assistant content to `memory` when `memory` is set.
+
+## Verification
+
+| ID | Tests / code |
+| --- | --- |
+| QRY-RAG-001–002, 010–013, 020–021 | `tests/bot/test_querybot.py` |
+| QRY-RAG-030–031 | `tests/test_streaming_async.py` (`AsyncQueryBot.stream_async`); `QRY-RAG-030` implementation in `llamabot/bot/querybot.py` |
+
+## Related Documents
+
+- [QueryBot LLD](./LLD.md)
+- [High-Level Design](../../high-level-design.md)

--- a/docs/designs/simplebot/LLD.md
+++ b/docs/designs/simplebot/LLD.md
@@ -1,0 +1,65 @@
+# SimpleBot and AsyncSimpleBot — Low-Level Design
+
+**Created**: 2026-03-28
+
+**Last updated**: 2026-03-28
+
+**HLD Link**: [../../high-level-design.md](../../high-level-design.md)
+
+## Requirements (EARS)
+
+- [simplebot-EARS.md](./simplebot-EARS.md) — `SimpleBot`, `AsyncSimpleBot`, shared completion helpers.
+
+## Overview
+
+`SimpleBot` is the **base completion stack** for most LlamaBot bots: **LiteLLM** (`completion` / `acompletion`) behind the shared message model, optional **recorder spans**, and **SQLite logging** of turns. Module-level helpers (`completion_kwargs_for_messages`, `make_response`, `make_async_response`, `stream_chunks`, `async_stream_chunks`, `stream_tokens_for_messages`, `extract_tool_calls`, `extract_content`) live in `llamabot.bot.simplebot` and are reused by `StructuredBot`, `ToolBot`, `QueryBot`, and others.
+
+## Classes
+
+| Class | Module | Base |
+| ----- | ------ | ---- |
+| `SimpleBot` | `llamabot.bot.simplebot` | — |
+| `AsyncSimpleBot` | `llamabot.bot.simplebot` | `SimpleBot` |
+
+## Shared completion pipeline
+
+LiteLLM calls are built by `completion_kwargs_for_messages`: `model`, `messages` (role/content from `BaseMessage.model_dump`), `temperature`, `stream`, `completion_kwargs`, optional `api_key`, `mock_response`, and—when a **`tools`** attribute exists on the bot—`tools` and `tool_choice`.
+
+- **Sync** responses: `make_response` → `litellm.completion`.
+- **Async** responses: `make_async_response` → `litellm.acompletion`.
+- **Streaming assembly**: `stream_chunks` (sync) and `async_stream_chunks` (async) consume LiteLLM streams when `stream_target` is not `"none"`; `stream_tokens_for_messages` yields text deltas for async streaming.
+
+`extract_tool_calls` / `extract_content` normalize `ModelResponse` into `AIMessage` fields and support **JSON-in-content** tool calls (e.g. some Ollama-style outputs) when `message.tool_calls` is absent.
+
+## Message composition
+
+`compose_messages_for_human_messages` builds:
+
+1. `SystemMessage` (from `system_prompt`).
+2. Optional **memory** messages via `memory.retrieve(...)` when `memory` is set (type `AbstractDocumentStore` in the constructor; used for chat history or RAG-style retrieval depending on implementation).
+3. **User** messages after `to_basemessage(...)`.
+
+## Call semantics
+
+- **`SimpleBot.__call__`**: Creates a **Span** (child of current span when present), records metadata, calls `make_response` + `stream_chunks`, builds `AIMessage` with content and tool calls, **sqlite_log**, and appends to `memory` when configured (last processed user message + assistant message).
+- **`AsyncSimpleBot.__call__`**: Uses **token streaming** via `stream_tokens_for_messages` and a `finalize` callback to assemble the final `AIMessage`, span fields, logging, and memory. Raises `RuntimeError` if no assistant message was assembled.
+
+## Configuration
+
+- **`stream_target`**: `stdout`, `panel`, `api`, or `none` (invalid values raise).
+- **`o1-preview` / `o1-mini`**: System prompt is coerced to `HumanMessage`, `temperature` set to `1.0`, `stream_target` forced to `none`.
+- **`json_mode`**: When `True`, `completion_kwargs_for_messages` requires `pydantic_model` on the bot (used by `StructuredBot`).
+
+## Traceability (intent → code)
+
+| EARS ID prefix | Code |
+| -------------- | ---- |
+| `CORE-SIMPLE-*` | `llamabot/bot/simplebot.py` |
+
+## Related Documents
+
+- [High-Level Design](../../high-level-design.md)
+- [StructuredBot LLD](../structuredbot/LLD.md) — Pydantic validation loop; subclasses `SimpleBot`.
+- [ToolBot LLD](../toolbot/LLD.md) — tool selection; subclasses `SimpleBot`.
+- [QueryBot LLD](../querybot/LLD.md) — RAG path (`compose_rag_messages`); does not use `SimpleBot.__call__` message composition.
+- [simplebot-EARS](./simplebot-EARS.md)

--- a/docs/designs/simplebot/simplebot-EARS.md
+++ b/docs/designs/simplebot/simplebot-EARS.md
@@ -1,0 +1,44 @@
+# SimpleBot and AsyncSimpleBot — EARS
+
+**Parent LLD**: [./LLD.md](./LLD.md)
+
+## Construction and streaming
+
+- [x] **CORE-SIMPLE-001**: The system shall provide a class `SimpleBot` whose constructor accepts `stream_target` only from the set `stdout`, `panel`, `api`, `none`; any other value shall raise `ValueError`.
+
+- [x] **CORE-SIMPLE-002**: Where `model_name` is `o1-preview` or `o1-mini`, the system shall set the system prompt to a `HumanMessage` with the same content, set `temperature` to `1.0`, and set `stream_target` to `none`.
+
+- [x] **CORE-SIMPLE-003**: The system shall build LiteLLM chat messages via `completion_kwargs_for_messages` using only `role` and `content` fields from each `BaseMessage`.
+
+- [x] **CORE-SIMPLE-004**: Where `json_mode` is true and the bot has no `pydantic_model` attribute, or `pydantic_model` is not a subclass of `pydantic.BaseModel`, `completion_kwargs_for_messages` shall raise `ValueError`.
+
+## Message composition and memory
+
+- [x] **CORE-SIMPLE-010**: When `memory` is set (document store), `compose_messages_for_human_messages` shall prepend the system prompt plus `memory.retrieve(...)` before the user messages converted via `to_basemessage`.
+
+- [x] **CORE-SIMPLE-011**: `SimpleBot.__call__` shall append the last processed user message and the assistant `AIMessage` to `memory` when `memory` is configured.
+
+## Completion and logging
+
+- [x] **CORE-SIMPLE-020**: `SimpleBot.__call__` shall record a span (child of the current span when one exists), call `make_response` / `stream_chunks`, construct an `AIMessage` with `extract_content` and `extract_tool_calls`, invoke `sqlite_log` for the full turn, and return that `AIMessage`.
+
+- [x] **CORE-SIMPLE-021**: `extract_tool_calls` shall return structured `tool_calls` when present; when absent and `message.content` is JSON describing tool calls (including single-object or list forms), the system shall synthesize `ChatCompletionMessageToolCall` objects.
+
+## AsyncSimpleBot
+
+- [x] **CORE-SIMPLE-030**: `AsyncSimpleBot.__call__` shall stream via `stream_tokens_for_messages` and shall raise `RuntimeError` if no assistant message is produced after streaming completes.
+
+## Verification
+
+| ID | Tests / code |
+| --- | --- |
+| CORE-SIMPLE-001–002 | `tests/bot/test_simplebot.py` (`test_simple_bot_init_invalid_stream_target`, o1 branches) |
+| CORE-SIMPLE-003–004 | `tests/bot/test_simplebot.py` (`completion_kwargs_for_messages` / JSON mode) |
+| CORE-SIMPLE-010–011 | `tests/bot/test_simplebot.py` (memory + `__call__` mocks) |
+| CORE-SIMPLE-020–021 | `tests/bot/test_simplebot.py` (`extract_tool_calls`, `extract_content`, `__call__`) |
+| CORE-SIMPLE-030 | `llamabot/bot/simplebot.py` (`AsyncSimpleBot.__call__`); streaming coverage in `tests/test_streaming_async.py` (`stream_async`) |
+
+## Related Documents
+
+- [SimpleBot LLD](./LLD.md)
+- [High-Level Design](../../high-level-design.md)

--- a/docs/designs/structuredbot/LLD.md
+++ b/docs/designs/structuredbot/LLD.md
@@ -1,0 +1,50 @@
+# StructuredBot and AsyncStructuredBot — Low-Level Design
+
+**Created**: 2026-03-28
+
+**Last updated**: 2026-03-28
+
+**HLD Link**: [../../high-level-design.md](../../high-level-design.md)
+
+## Requirements (EARS)
+
+- [structuredbot-EARS.md](./structuredbot-EARS.md) — `StructuredBot`, `AsyncStructuredBot`, Pydantic validation loop.
+
+## Overview
+
+`StructuredBot` subclasses `SimpleBot` but does **not** use `SimpleBot.__call__` for its main path. It runs a dedicated loop that asks the model for JSON, validates against a **Pydantic** model, and retries with validation errors in the conversation until success or `num_attempts` is exhausted.
+
+## Classes
+
+| Class | Module | Base |
+| ----- | ------ | ---- |
+| `StructuredBot` | `llamabot.bot.structuredbot` | `SimpleBot` |
+| `AsyncStructuredBot` | `llamabot.bot.structuredbot` | `StructuredBot` |
+
+## Model gate
+
+`StructuredBot.__init__` validates that the LiteLLM model supports `response_format` / `response_schema` (via `get_supported_openai_params` / `supports_response_schema`), except for **`ollama_chat`** in the model name string where the check is skipped.
+
+## Message composition
+
+`compose_structured_first_attempt_messages` uses **only** `[system_prompt] + to_basemessage(user)`—no `memory` retrieval path. `StructuredBot` does not expose `memory` on its constructor; it does not participate in the `SimpleBot` memory/docstore flow for structured calls.
+
+## `__call__` loop
+
+Iterates up to `num_attempts`: `make_response` + `stream_chunks`, `extract_content`, `json.loads`, `pydantic_model.model_validate`. On failure, extends the message list with the last assistant content and a `HumanMessage` describing the validation error (`get_validation_error_message`). On final failure, `allow_failed_validation` may return `model_construct(**last_codeblock)`.
+
+## Async
+
+`AsyncStructuredBot.__call__` runs the synchronous `StructuredBot.__call__` in **`asyncio.to_thread`**. `stream_async` streams one structured attempt without validation on partial chunks (see code).
+
+## Traceability (intent → code)
+
+| EARS ID prefix | Code |
+| -------------- | ---- |
+| `CORE-STRUCT-*` | `llamabot/bot/structuredbot.py` |
+
+## Related Documents
+
+- [High-Level Design](../../high-level-design.md)
+- [SimpleBot LLD](../simplebot/LLD.md) — shared LiteLLM helpers (`make_response`, `stream_chunks`, `completion_kwargs_for_messages`).
+- [structuredbot-EARS](./structuredbot-EARS.md)

--- a/docs/designs/structuredbot/structuredbot-EARS.md
+++ b/docs/designs/structuredbot/structuredbot-EARS.md
@@ -1,0 +1,42 @@
+# StructuredBot and AsyncStructuredBot — EARS
+
+**Parent LLD**: [./LLD.md](./LLD.md)
+
+## Model and initialization
+
+- [x] **CORE-STRUCT-001**: Where the model name contains `ollama_chat`, `StructuredBot.__init__` shall not require `response_format` and `response_schema` in supported OpenAI params.
+
+- [x] **CORE-STRUCT-002**: For other models, where `response_format` with `response_schema` is not supported, `StructuredBot.__init__` shall raise `ValueError` with guidance to use a compatible model.
+
+- [x] **CORE-STRUCT-003**: `StructuredBot` shall call `SimpleBot.__init__` with `json_mode=True` and the supplied `model_name` and `stream_target`.
+
+## Structured message composition
+
+- [x] **CORE-STRUCT-010**: `compose_structured_first_attempt_messages` shall return `full_messages` equal to `[system_prompt]` plus `to_basemessage(user_messages)` with no memory retrieval.
+
+## Validation loop
+
+- [x] **CORE-STRUCT-020**: `StructuredBot.__call__` shall attempt up to `num_attempts` completions; on each attempt it shall parse assistant content as JSON and validate with `pydantic_model.model_validate`.
+
+- [x] **CORE-STRUCT-021**: On `ValidationError` before the last attempt, the system shall extend the conversation with the prior assistant message and the `HumanMessage` from `get_validation_error_message`.
+
+- [x] **CORE-STRUCT-022**: On the last attempt, if validation fails and `allow_failed_validation` is true and a parsed dict exists, the system shall return `pydantic_model.model_construct(**last_codeblock)`; otherwise it shall re-raise the validation error.
+
+## AsyncStructuredBot
+
+- [x] **CORE-STRUCT-030**: `AsyncStructuredBot.__call__` shall execute the synchronous `StructuredBot.__call__` via `asyncio.to_thread` with the same `num_attempts` and `verbose` arguments.
+
+## Verification
+
+| ID | Tests / code |
+| --- | --- |
+| CORE-STRUCT-001–003 | `tests/bot/test_structuredbot.py` (model support / init) |
+| CORE-STRUCT-010 | `tests/bot/test_structuredbot.py` (`compose_structured_first_attempt_messages`) |
+| CORE-STRUCT-020–022 | `tests/bot/test_structuredbot.py` (validation loop, `allow_failed_validation`) |
+| CORE-STRUCT-030 | `llamabot/bot/structuredbot.py` (`AsyncStructuredBot.__call__` → `asyncio.to_thread`); no dedicated pytest for `__call__` yet |
+
+## Related Documents
+
+- [StructuredBot LLD](./LLD.md)
+- [SimpleBot LLD](../simplebot/LLD.md)
+- [High-Level Design](../../high-level-design.md)

--- a/docs/designs/toolbot/LLD.md
+++ b/docs/designs/toolbot/LLD.md
@@ -1,0 +1,54 @@
+# ToolBot and AsyncToolBot — Low-Level Design
+
+**Created**: 2026-03-28
+
+**Last updated**: 2026-03-28
+
+**HLD Link**: [../../high-level-design.md](../../high-level-design.md)
+
+## Requirements (EARS)
+
+- [toolbot-EARS.md](./toolbot-EARS.md) — `ToolBot`, `AsyncToolBot`, tool schemas and chat memory.
+
+## Overview
+
+`ToolBot` performs single-turn **tool selection**: the model returns **function calls**, and the bot exposes a **list of `ChatCompletionMessageToolCall`** (not a user-facing assistant string). `AsyncToolBot` uses native **`acompletion`** and **`async_stream_chunks`**—no `asyncio.to_thread` around the sync `ToolBot.__call__`.
+
+## Classes
+
+| Class | Module | Base |
+| ----- | ------ | ---- |
+| `ToolBot` | `llamabot.bot.toolbot` | `SimpleBot` |
+| `AsyncToolBot` | `llamabot.bot.toolbot` | `ToolBot` |
+
+## Tools and memory
+
+- Constructor accepts `tools` and `chat_memory` (`ChatMemory` default). When `tools` is empty or missing `DEFAULT_TOOLS` by name, **`DEFAULT_TOOLS` is prepended** (`llamabot.components.tools`).
+- Each tool’s `json_schema` is passed to LiteLLM as `tools`; `name_to_tool_map` maps function names back to callables.
+
+## Message composition
+
+`compose_tool_messages`:
+
+1. Resolves `Callable` arguments by calling them (must return `str`).
+2. `system_prompt` + `chat_memory.retrieve(first_user_content)` when `user_messages` exist.
+3. Optional `execution_history` (last five calls) as a `SystemMessage` prefix.
+4. Appends user messages.
+
+## Call semantics
+
+- **`ToolBot.__call__`**: `make_response` + `stream_chunks`, `extract_tool_calls`, updates `chat_memory` with first user message and `AIMessage(content=str(tool_calls))`.
+- **`AsyncToolBot.__call__`**: `make_async_response` + `async_stream_chunks`, then same extraction and memory updates.
+
+## Traceability (intent → code)
+
+| EARS ID prefix | Code |
+| -------------- | ---- |
+| `CORE-TOOL-*` | `llamabot/bot/toolbot.py` |
+
+## Related Documents
+
+- [High-Level Design](../../high-level-design.md)
+- [SimpleBot LLD](../simplebot/LLD.md) — shared LiteLLM helpers.
+- [AgentBot LLD](../agentbot/LLD.md) — PocketFlow graph uses `ToolBot` / `AsyncToolBot` inside `DecideNode`.
+- [toolbot-EARS](./toolbot-EARS.md)

--- a/docs/designs/toolbot/toolbot-EARS.md
+++ b/docs/designs/toolbot/toolbot-EARS.md
@@ -1,0 +1,45 @@
+# ToolBot and AsyncToolBot — EARS
+
+**Parent LLD**: [./LLD.md](./LLD.md)
+
+## Tool registration
+
+- [x] **CORE-TOOL-001**: Where `tools` is `None` or empty, `ToolBot.__init__` shall use `DEFAULT_TOOLS` as the full tool list.
+
+- [x] **CORE-TOOL-002**: Where `tools` is non-empty and does not include all `DEFAULT_TOOLS` by function name, the system shall prepend `DEFAULT_TOOLS` before the user tools.
+
+- [x] **CORE-TOOL-003**: The system shall expose LiteLLM `tools` as the list of `json_schema` attributes from the resolved tool functions and shall map `__name__` to the callable in `name_to_tool_map`.
+
+## Message composition
+
+- [x] **CORE-TOOL-010**: `compose_tool_messages` shall resolve callable arguments by invoking them and requiring a `str` result wrapped in `HumanMessage`.
+
+- [x] **CORE-TOOL-011**: When `chat_memory` is set and user messages exist, the message list shall include `chat_memory.retrieve(user_messages[0].content)` after the system prompt.
+
+- [x] **CORE-TOOL-012**: When `execution_history` is provided, the system shall append a `SystemMessage` summarizing up to the last five tool calls before the user messages.
+
+## ToolBot sync
+
+- [x] **CORE-TOOL-020**: `ToolBot.__call__` shall return the list from `extract_tool_calls` after `make_response` and `stream_chunks`, and shall append the first user message and an `AIMessage` whose content is the string representation of that tool-call list to `chat_memory`.
+
+## AsyncToolBot
+
+- [x] **CORE-TOOL-030**: `AsyncToolBot.__call__` shall obtain completions via `make_async_response` and shall assemble the final `ModelResponse` with `async_stream_chunks` before `extract_tool_calls`.
+
+- [x] **CORE-TOOL-031**: `AsyncToolBot.__call__` shall not wrap synchronous `ToolBot.__call__` in `asyncio.to_thread`; it shall use native `acompletion`.
+
+## Verification
+
+| ID | Tests / code |
+| --- | --- |
+| CORE-TOOL-001–003 | `tests/bot/test_toolbot.py` |
+| CORE-TOOL-010–012 | `tests/bot/test_toolbot.py` (`compose_tool_messages`) |
+| CORE-TOOL-020 | `tests/bot/test_toolbot.py` |
+| CORE-TOOL-030–031 | `tests/bot/test_async_toolbot_call.py`, `llamabot/bot/toolbot.py` (`AsyncToolBot`) |
+
+## Related Documents
+
+- [ToolBot LLD](./LLD.md)
+- [SimpleBot LLD](../simplebot/LLD.md)
+- [AgentBot reference graph EARS](../agentbot/reference-graph-EARS.md)
+- [High-Level Design](../../high-level-design.md)

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-03-28
 
-**Last updated**: 2026-03-28 — Decision 3: sync routing uses `ToolBot.__call__`; async routing uses `AsyncToolBot.__call__` (`acompletion`). See [AgentBot LLD](designs/agentbot/LLD.md).
+**Last updated**: 2026-03-28 — Design docs use one folder per bot under `designs/` (e.g. SimpleBot, StructuredBot, ToolBot, QueryBot, AgentBot). Decision 3: sync routing uses `ToolBot.__call__`; async routing uses `AsyncToolBot.__call__` (`acompletion`). See [AgentBot LLD](designs/agentbot/LLD.md).
 
 ## Problem Statement
 
@@ -75,7 +75,13 @@ Researchers and developers need a **Pythonic**, **composable** way to call many 
 
 ## Related Designs
 
-- [AgentBot reference PocketFlow graph (LLD)](designs/agentbot/LLD.md)
+Bot types (each has its own LLD + EARS under `designs/<bot>/`):
+
+- [SimpleBot (LLD)](designs/simplebot/LLD.md)
+- [StructuredBot (LLD)](designs/structuredbot/LLD.md)
+- [ToolBot (LLD)](designs/toolbot/LLD.md)
+- [QueryBot (LLD)](designs/querybot/LLD.md)
+- [AgentBot — reference PocketFlow graph (LLD)](designs/agentbot/LLD.md)
 - [Unified chat memory (topic note)](design/unified_chat_memory.md)
 - [Observability (topic note)](design/observability.md)
 - [Log viewer (topic note)](design/log_viewer.md)

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -65,6 +65,18 @@ nav:
     - "MCP Server": cli/mcp.md
   - Design & Explanation:
     - "High-Level Design (HLD)": high-level-design.md
+    - "SimpleBot":
+      - "LLD": designs/simplebot/LLD.md
+      - "EARS": designs/simplebot/simplebot-EARS.md
+    - "StructuredBot":
+      - "LLD": designs/structuredbot/LLD.md
+      - "EARS": designs/structuredbot/structuredbot-EARS.md
+    - "ToolBot":
+      - "LLD": designs/toolbot/LLD.md
+      - "EARS": designs/toolbot/toolbot-EARS.md
+    - "QueryBot (RAG)":
+      - "LLD": designs/querybot/LLD.md
+      - "EARS": designs/querybot/querybot-EARS.md
     - "AgentBot reference graph":
       - "LLD": designs/agentbot/LLD.md
       - "EARS": designs/agentbot/reference-graph-EARS.md


### PR DESCRIPTION
## Summary

- Split design documentation into one folder per bot under `docs/designs/`: `simplebot/`, `structuredbot/`, `toolbot/`, plus new `querybot/` LLD and EARS.
- Updated the HLD related-designs list, MkDocs nav, `AGENTS.md` (convention note), and AgentBot LLD cross-links.

## Motivation

Aligns DDD layout with how bot types are organized: each bot has its own LLD and EARS instead of a single combined `core-bots` document.

Made with [Cursor](https://cursor.com)