### PR TITLE
feat: first-class MCP tools for bots + marimo-pair skill

### DIFF
--- a/.agents/skills/design-driven-dev/references/ears-syntax.md
+++ b/.agents/skills/design-driven-dev/references/ears-syntax.md
@@ -2,7 +2,7 @@
 
 EARS (Easy Approach to Requirements Syntax) provides structured patterns for writing unambiguous, testable requirements.
 
-**Source**: https://alistairmavin.com/ears/
+**Source**: <https://alistairmavin.com/ears/>
 
 ## File Location
 
@@ -62,6 +62,7 @@ Each EARS file contains requirements with status markers:
 - **NNN**: Sequential number, zero-padded (001, 002, ...)
 
 **Example IDs:**
+
 - `AUTH-LOGIN-001` - Auth feature, login sub-feature, requirement 1
 - `PAY-CHECKOUT-010` - Payments feature, checkout sub-feature, requirement 10
 - `CART-EDIT-005` - Cart feature, edit sub-feature, requirement 5
@@ -121,11 +122,13 @@ A spec should be interpretable correctly even if found via grep without surround
 ### Examples
 
 **Bad** — sounds universal, actually scoped to one notification channel:
+
 ```
 - **NOTIF-BE-003**: Notifications shall use a 30-second delivery timeout.
 ```
 
 **Good** — scope is explicit:
+
 ```
 - **NOTIF-BE-003**: Both email and push notifications shall use a 30-second delivery timeout.
 ```

--- a/.agents/skills/marimo-pair/.claude-plugin/marketplace.json
+++ b/.agents/skills/marimo-pair/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "marimo-pair",
+  "owner": {
+    "name": "marimo-team",
+    "email": "contact@marimo.io"
+  },
+  "metadata": {
+    "description": "Pair programming protocol for marimo notebooks",
+    "version": "0.0.13"
+  },
+  "plugins": [
+    {
+      "name": "marimo-pair",
+      "description": "Pair programming protocol for marimo notebooks",
+      "source": "./",
+      "skills": [
+        "./"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/marimo-pair/.github/workflows/release.yml
+++ b/.agents/skills/marimo-pair/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+
+      - name: Bump version
+        id: bump
+        run: |
+          current=$(jq -r '.metadata.version' .claude-plugin/marketplace.json)
+          IFS='.' read -r major minor patch <<< "$current"
+
+          if [ "${{ inputs.bump }}" = "minor" ]; then
+            minor=$((minor + 1))
+            patch=0
+          else
+            patch=$((patch + 1))
+          fi
+
+          new="${major}.${minor}.${patch}"
+          echo "version=${new}" >> "$GITHUB_OUTPUT"
+
+          jq --arg v "$new" '.metadata.version = $v' .claude-plugin/marketplace.json > tmp.json
+          mv tmp.json .claude-plugin/marketplace.json
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/marketplace.json
+          git commit -m "Release v${{ steps.bump.outputs.version }}"
+          git tag "v${{ steps.bump.outputs.version }}"
+          git push origin main --tags
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.bump.outputs.version }}" \
+            --title "v${{ steps.bump.outputs.version }}" \
+            --generate-notes

--- a/.agents/skills/marimo-pair/LICENSE
+++ b/.agents/skills/marimo-pair/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Marimo Team
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/skills/marimo-pair/README.md
+++ b/.agents/skills/marimo-pair/README.md
@@ -1,0 +1,74 @@
+<h1>
+<p align="center">
+  /marimo-pair
+</h1>
+<p align="center">
+  reactive Python notebooks as environments for agents
+</p>
+</p>
+
+<div align="center">
+  <video src="https://github.com/user-attachments/assets/d6d3f57a-e997-423c-bf14-8d9fba75e310" width="600" controls></video>
+</div>
+
+## Prerequisites
+
+- A running [marimo](https://marimo.io) notebook (`--no-token` for
+  auto-discovery; `MARIMO_TOKEN` env var for servers with auth)
+- `bash`, `curl`, and `jq` available on `PATH` (on Windows, run from
+  Git Bash)
+
+## Install
+
+### Agent Skills (any tool)
+
+Works with any agent that supports the [Agent Skills](https://agentskills.io)
+open standard:
+
+```bash
+npx skills add marimo-team/marimo-pair
+
+# or upgrade an existing install
+npx skills upgrade marimo-team/marimo-pair
+```
+
+If you don't have `npx` installed but have `uv`:
+
+```bash
+uvx deno -A npm:skills add marimo-team/marimo-pair
+```
+
+### Claude Code (plugin)
+
+Add the marketplace and install the plugin:
+
+```
+/plugin marketplace add marimo-team/marimo-pair
+/plugin install marimo-pair@marimo-team-marimo-pair
+```
+
+To opt in to auto-updates (recommended), so you always get the latest version:
+
+```
+/plugin → Marketplaces → marimo-team-marimo-pair → Enable auto-update
+```
+
+## FAQ
+
+### I keep getting prompted to allow Bash commands
+
+The skill declares its own `allowed-tools`, but Claude Code may still prompt
+you to approve each Bash call. To avoid repeated prompts, copy the absolute
+paths to the scripts from the installed skill and add them to your
+`.claude/settings.json` (project-level) or `~/.claude/settings.json` (global):
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash /path/to/skills/marimo-pair/scripts/discover-servers.sh *)",
+      "Bash(bash /path/to/skills/marimo-pair/scripts/execute-code.sh *)"
+    ]
+  }
+}
+```

--- a/.agents/skills/marimo-pair/SKILL.md
+++ b/.agents/skills/marimo-pair/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: marimo-pair
+description: >-
+  Work inside a running marimo notebook's kernel — execute code, create cells,
+  and build a notebook as an artifact. Use when the user wants to start a
+  marimo notebook or work in an active marimo session.
+allowed-tools: Bash(bash **/scripts/discover-servers.sh *), Bash(bash **/scripts/execute-code.sh *), Read
+---
+
+# marimo Pair Programming Protocol
+
+This skill gives you full access to a running marimo notebook. You can read
+cell code, create and edit cells, install packages, run cells, and inspect
+the reactive graph — all programmatically. The user sees results live in their
+browser while you work through bundled scripts or MCP.
+
+## Philosophy
+
+marimo notebooks are a dataflow graph — cells are the fundamental unit of
+computation, connected by the variables they define and reference. When a cell
+runs, marimo automatically re-executes downstream cells. You have full access
+to the running notebook.
+
+- **Cells are your main lever.** Use them to break up work and choose how and
+  when to bring the human into the loop. Not every cell needs rich output —
+  sometimes the object itself is enough, sometimes a summary is better.
+  Match the presentation to the intent.
+- **Understand intent first.** When clear, act. When ambiguous, clarify.
+- **Follow existing signal.** Check imports, `pyproject.toml`, existing cells,
+  and `dir(ctx)` before reaching for external tools.
+- **Stay focused.** Build first, polish later — cell names, layout, and styling
+  can wait.
+
+## Prerequisites
+
+### How to invoke marimo
+
+Only servers started with `--no-token` register in the local server registry
+and are auto-discoverable — starting without a token makes discovery easier.
+If a server has a token, set the `MARIMO_TOKEN` environment variable before
+calling the execute script (avoids leaking the token in process listings). The
+right way to invoke marimo depends on context (project
+tooling, global install, sandbox mode). See
+[finding-marimo.md](reference/finding-marimo.md) for the full decision tree.
+
+**Do NOT use `--headless` unless the user asks for it.** Omitting it lets
+marimo auto-open the browser, which is the expected pairing experience. If the
+user explicitly requests headless, offer to open `http://localhost:<port>`
+in their browser (`open` on macOS, `xdg-open` on Linux, `start` on Windows).
+
+## Troubleshooting
+
+### `SyntaxError` or `ImportError` from `execute-code.sh`
+
+Code runs **inside the running marimo kernel** — `execute-code.sh` POSTs it
+over HTTP and never invokes a local Python. So errors here are not caused by
+the local Python version, missing venv, or `uv` vs `pip` — they're problems
+with the code being sent. Fix the code (use a heredoc for anything
+multiline; don't try to one-line compound statements with `;`).
+
+### User keeps getting prompted to allow Bash commands
+
+The skill declares `allowed-tools` in its frontmatter, but Claude Code may
+still prompt for each Bash call. To fix this, the user should add the absolute
+paths to the scripts to their `.claude/settings.json` (project-level) or
+`~/.claude/settings.json` (global):
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash /absolute/path/to/skills/marimo-pair/scripts/discover-servers.sh *)",
+      "Bash(bash /absolute/path/to/skills/marimo-pair/scripts/execute-code.sh *)"
+    ]
+  }
+}
+```
+
+## How to Discover Servers and Execute Code
+
+Two operations: **discover servers** and **execute code**.
+
+| Operation | Script | MCP |
+|-----------|--------|-----|
+| Discover servers | `bash scripts/discover-servers.sh` | `list_sessions()` tool |
+| Execute code | `bash scripts/execute-code.sh -c "code"` | `execute_code(code=..., session_id=...)` tool |
+| Execute code (multiline) | `bash scripts/execute-code.sh <<'EOF'` | same |
+| Execute code (by URL) | `bash scripts/execute-code.sh --url http://localhost:2718 -c "code"` | same (with `url` param) |
+
+Scripts auto-discover sessions from the local server registry. Use
+`--port` to target a specific server when multiple are running,
+`--session` to target a specific session when multiple notebooks are
+open on the same server, or `--url` to skip discovery and connect to a
+server by URL (e.g. `--url http://localhost:2718`). **On Windows, prefer
+direct `--url` when registry discovery is empty** — see the next section
+for why. Set the `MARIMO_TOKEN` env var to authenticate when the server
+has token auth enabled (`--token` flag also works but exposes the token
+in process listings). If the server was started with `--mcp`, you'll
+have MCP tools available as an alternative.
+
+### Discovery finds nothing but the user has a server running?
+
+Only `--no-token` servers are in the registry. If discovery comes up empty,
+the server likely has token auth — ask the user for the token and set it as
+the `MARIMO_TOKEN` environment variable.
+
+On **Windows (Git Bash / MSYS2)**, discovery can also come up empty even for
+a running `--no-token` server. If the user confirms marimo is reachable
+locally, fall back to `--url http://127.0.0.1:<port>` (ask for the port).
+
+### No servers running?
+
+**Always discover before starting.** Background task "completed" notifications
+do not mean the server died — check the output or run discover first.
+
+If no servers are found, read the user's intent — if they want a notebook,
+start one. **Always start marimo as a background task** (using
+`run_in_background` on the Bash tool) so the server automatically gets cleaned
+up when the session ends and doesn't block the conversation. See
+[finding-marimo.md](reference/finding-marimo.md).
+
+If there's no `.py` file yet, pick a descriptive filename based on context
+(e.g., `exploration.py`, `analysis.py`, `dashboard.py`). Don't ask — just
+pick something reasonable.
+
+**Avoid shell escaping issues.** `-c` works for simple one-liners, but for
+multiline code or code with quotes/backticks/`${}`, use a heredoc or a file:
+
+```bash
+# heredoc (single-quoted delimiter prevents shell interpolation)
+bash scripts/execute-code.sh <<'EOF'
+import marimo._code_mode as cm
+
+async with cm.get_context() as ctx:
+    ctx.create_cell("x = 1")
+EOF
+
+# file
+bash scripts/execute-code.sh /tmp/code.py
+
+# target a specific port (skips auto-selection when multiple servers run)
+bash scripts/execute-code.sh --port 2718 -c "1 + 1"
+```
+
+## Executing Code
+
+Every execute-code call runs inside the notebook's kernel. All cell variables
+are in scope — `print(df.head())` just works. Nothing you define persists
+between calls (variables, imports, side-effects all reset), but you can freely
+introspect the notebook: inspect variables, test code snippets, check types
+and shapes. Use this to explore, prototype, and validate before committing
+anything to the notebook — then create cells to persist state and make results
+visible to the user.
+
+To mutate the notebook's dataflow graph — create, edit, and delete cells,
+install packages, and run cells — use `marimo._code_mode`:
+
+```python
+import marimo._code_mode as cm
+
+async with cm.get_context() as ctx:
+    cid = ctx.create_cell("x = 1")
+    ctx.packages.add("pandas")
+    ctx.run_cell(cid)
+```
+
+You **must** use `async with` — without it, operations silently do nothing.
+All `ctx.*` methods are **synchronous** — they queue operations and the
+context manager flushes them on exit. Do **not** `await` them.
+
+The kernel supports top-level `await`, so use `async with` directly. Do
+**not** wrap calls in `async def main(): ...` + `asyncio.run(main())` — it's
+unnecessary and easy to get wrong (compound statements like `async with`
+can't follow `def name():` on the same line, so cramming it into a `-c`
+one-liner produces a `SyntaxError`).
+
+**Cells are not auto-executed.** `create_cell` and `edit_cell` are structural
+changes only — use `run_cell` to queue execution.
+
+`code_mode` is a tested, safe API for notebook mutations — prefer it for all
+structural changes. You also have access to marimo internals from the kernel,
+but treat that as a last resort and only with high confidence after exploration.
+
+**UI state lives outside the reactive graph.** Anywidget traitlets can be read
+or set directly (e.g., `slider.value = 5`). For `mo.ui.*` elements, use
+`ctx.set_ui_value(element, new_value)` inside `code_mode`.
+
+### First Step: Explore the API
+
+The `code_mode` API can change between marimo versions. Explore it at the
+start of each session — dig deeper into anything you're unsure about.
+
+```python
+import marimo._code_mode as cm
+help(cm)
+```
+
+## Guard Rails
+
+Skip these and the UI breaks:
+
+- **Install packages via `ctx.packages.add()`, not `uv add` or `pip`.**
+  The code API handles kernel restarts and dependency resolution correctly.
+  Only fall back to external CLIs if the API is unavailable or fails.
+- **Custom widget = anywidget.** For bespoke visual components, use anywidget
+  with HTML/CSS/JS. Composed `mo.ui` is fine for simple forms and controls.
+  See [rich-representations.md](reference/rich-representations.md).
+- **NEVER write to the `.py` file directly while a session is running — the kernel owns it.**
+- **No temp-file deps in cells.** `pathlib.Path("/tmp/...")` in cell code is a bug.
+- **Avoid empty cells.** Prefer `edit_cell` into existing empty cells rather
+  than creating new ones. Clean up any cells that end up empty after edits.
+- **Don't worry about cell names.** Most cells don't need explicit names —
+  see [notebook-improvements.md](reference/notebook-improvements.md#cell-names).
+
+## Widgets and Reactivity
+
+Anywidget state (traitlets) lives outside marimo's reactive graph. To hook a
+widget trait into the graph, pick one strategy per widget — never mix them:
+
+- **`mo.state` + `.observe()`** — you pick specific traits to bridge. Default choice.
+- **`mo.ui.anywidget()`** — wraps all synced traits into one reactive `.value`. Convenient but coarser.
+
+Read [rich-representations.md](reference/rich-representations.md) before wiring either.
+
+## Keep in Mind
+
+- **The user is editing too.** The notebook can change between your calls —
+  re-inspect notebook state if it's been a while since you last looked.
+- **Deletions are destructive.** Deleting a cell removes its variables from
+  kernel memory — restoring means recreating the cell and re-running it and
+  its dependents. If intent seems ambiguous, ask first.
+- **Installing packages changes the project.** `ctx.packages.add()` adds
+  real dependencies — confirm when it's not obvious from context.
+
+## References
+
+- [finding-marimo.md](reference/finding-marimo.md) — how to find and invoke the right marimo
+- [gotchas.md](reference/gotchas.md) — cached module proxies and other traps
+- [rich-representations.md](reference/rich-representations.md) — custom widgets and visualizations
+- [notebook-improvements.md](reference/notebook-improvements.md) — improving existing notebooks

--- a/.agents/skills/marimo-pair/reference/finding-marimo.md
+++ b/.agents/skills/marimo-pair/reference/finding-marimo.md
@@ -1,0 +1,70 @@
+# Finding and Invoking marimo
+
+Only servers started with `--no-token` register in the local server registry
+and are auto-discoverable — starting without a token makes discovery easier.
+If a server has a token, set the `MARIMO_TOKEN` environment variable before
+calling the execute script (avoids leaking the token in process listings).
+
+```sh
+marimo edit notebook.py --no-token [--sandbox]
+```
+
+How you invoke `marimo` depends on context — find the right way to run it.
+
+## Inside a Python project
+
+If there's a `pyproject.toml` in cwd or a parent directory, check that marimo
+is actually in the dependencies before using the project's runner. Look for
+`marimo` in:
+
+- `[project.dependencies]`
+- `[project.optional-dependencies]` or `[dependency-groups]` (dev deps)
+- `[tool.pixi.dependencies]`
+- The project's `.venv` (`uv pip show marimo` or check `.venv/bin/marimo`)
+
+If marimo is in a named dependency group (not the default), you need to
+specify it:
+
+```sh
+# marimo is in [dependency-groups] → "notebooks" group
+uv run --group notebooks marimo edit notebook.py --no-token
+```
+
+Once you know marimo is available, use whatever CLI runner the project uses:
+
+```sh
+# uv-managed project
+uv run marimo edit notebook.py --no-token
+# pixi-managed project
+pixi run marimo edit notebook.py --no-token
+```
+
+Skip `--sandbox` here — the project already manages dependencies.
+
+If `pyproject.toml` exists but marimo is **not** in the deps, treat this as
+"outside a project" (see below).
+
+## Outside a Python project
+
+Prefer `--sandbox`. Sandbox mode creates an isolated environment for the
+notebook and writes dependencies into the script itself as inline PEP 723
+metadata — so the notebook stays self-contained and reproducible.
+
+```sh
+# With uv available (preferred)
+uvx marimo@latest edit notebook.py --no-token --sandbox
+
+# With marimo installed globally
+marimo edit notebook.py --no-token --sandbox
+```
+
+## Global marimo install
+
+If marimo is installed globally, check the version — code mode shipped in
+v0.21.1. If the installed version is older, prompt the user to upgrade before
+proceeding.
+
+## Nothing found
+
+If no project marimo, no `uv`/`uvx`, and no global `marimo` on PATH, tell the
+user to install `uv` (<https://docs.astral.sh/uv/getting-started/installation/>).

--- a/.agents/skills/marimo-pair/reference/gotchas.md
+++ b/.agents/skills/marimo-pair/reference/gotchas.md
@@ -1,0 +1,66 @@
+# Gotchas
+
+## Private variables are cell-scoped
+
+Variables with a `_` prefix are **private to the cell that defines them** in
+marimo. They cannot be referenced from other cells — you'll get a `NameError`.
+
+This matters when building notebooks programmatically. A common mistake:
+
+```python
+# Cell A
+_df = pd.DataFrame(results)   # _df is private to this cell
+
+# Cell B — FAILS
+mo.ui.table(_df)               # NameError: name '_df' is not defined
+```
+
+**Fix:** Either merge both into one cell, or use a non-private name (`df`).
+
+## Duplicate public imports across cells
+
+marimo enforces single-definition: a public name (like `pd`) can only be
+defined in one cell. If two cells both `import pandas as pd`, you get a
+`Multiply-defined names` error at validation.
+
+**Fix:** Use a `_` prefix on the second import (`import pandas as _pd`) or
+consolidate imports into a shared cell.
+
+## `inspect.getsource()` on methods is indented
+
+`inspect.getsource()` on a class method preserves the original indentation.
+Passing this to `ast.parse()` fails with `IndentationError`.
+
+```python
+# FAILS
+src = inspect.getsource(SomeClass.some_method)
+tree = ast.parse(src)  # IndentationError: unexpected indent
+
+# FIX
+import textwrap
+src = textwrap.dedent(inspect.getsource(SomeClass.some_method))
+tree = ast.parse(src)
+```
+
+## Cached module availability
+
+Some libraries cache optional-dependency availability at import time. Installing
+a package mid-session via `ctx.packages.add()` won't update those caches.
+The user may need to restart the kernel — but try known workarounds first.
+
+### Polars + pyarrow
+
+`df.to_pandas()` fails with `ModuleNotFoundError: pa.Table requires 'pyarrow'`.
+
+**Workaround** — if this error occurs after installing pyarrow mid-session,
+run the following via `execute-code` (scratchpad), NOT in a cell. The patch
+mutates the cached module object in the running kernel, so it doesn't need to
+persist in the notebook.
+
+```python
+import pyarrow as _pa
+import polars.dataframe.frame as _frame_mod
+_frame_mod.pa = _pa
+```
+
+Then re-run the failing cell.

--- a/.agents/skills/marimo-pair/reference/notebook-improvements.md
+++ b/.agents/skills/marimo-pair/reference/notebook-improvements.md
@@ -1,0 +1,91 @@
+# Notebook Improvements
+
+When the user asks to improve, optimize, or clean up their notebook, scan the
+current cells for these opportunities. Use your judgment — don't over-apply,
+and if you're unsure whether a change is worthwhile, ask the user.
+
+## Cell names
+
+Low priority unless the user asks. `setup` and cells defining
+functions/classes are auto-named by marimo. Beyond that, naming is optional.
+Note that naming markdown cells clutters the UI by showing the cell header
+that's normally hidden.
+
+## Setup cell
+
+A setup cell is named `"setup"` and is guaranteed to run before all other
+cells. It's the place for module imports. Consolidating imports here keeps
+the notebook clean and ensures every cell can rely on those modules being
+available.
+
+First check if the notebook already has a cell named `"setup"`. If not,
+create one and hoist scattered imports into it:
+
+```python
+cid = ctx.create_cell('''import polars as pl
+import marimo as mo
+import anywidget
+import traitlets''', name="setup")
+ctx.run_cell(cid)
+```
+
+If a setup cell already exists, use `ctx.edit_cell("setup", code=...)` and
+`ctx.run_cell("setup")` to modify and re-run it.
+
+## Lift reusable functions into their own cells
+
+When a cell contains a single function or class that doesn't reference
+variables from other cells, marimo treats it specially — it can be written as
+a standalone definition and reused outside the notebook. These functions can
+use modules from the setup cell.
+
+Look for functions that **could belong in a library**: data loading, transforms,
+parsers, domain logic, custom widgets. If someone might reasonably `import` it
+from another module, it's a good candidate to lift into its own cell.
+
+Don't lift everything — notebook-specific wiring (UI layout, display logic,
+cell-level orchestration) should stay where it is. Use `_prefix` for
+cell-internal helpers that aren't meant to be reused.
+
+```python
+# before: useful logic buried in a larger cell
+objects = pl.read_csv("https://example.com/objects.csv")
+artists = pl.read_csv("https://example.com/artists.csv")
+
+def top_counts(df, col, n=5):
+    return df.group_by(col).len().sort("len", descending=True).head(n)
+
+result = top_counts(objects.join(artists, on="id"), "category")
+```
+
+```python
+# after: top_counts is general-purpose — give it its own cell
+
+# cell 1
+def top_counts(df, col, n=5):
+    return df.group_by(col).len().sort("len", descending=True).head(n)
+```
+
+```python
+# cell 2
+result = top_counts(df, "category")
+```
+
+## `mo.persistent_cache`
+
+`@mo.persistent_cache` caches a function's result to disk so it isn't
+recomputed on subsequent runs. The cache persists across kernel restarts.
+
+```python
+@mo.persistent_cache
+def load_data():
+    objects = pl.read_csv("https://example.com/objects.csv")
+    artists = pl.read_csv("https://example.com/artists.csv")
+    return objects.join(artists, on="id", how="left")
+
+df = load_data()
+```
+
+Good candidates: data loading, ETL, expensive computation that rarely changes.
+Don't over-optimize — if you're unsure, suggest it to the user rather than
+applying it.

--- a/.agents/skills/marimo-pair/reference/rich-representations.md
+++ b/.agents/skills/marimo-pair/reference/rich-representations.md
@@ -1,0 +1,302 @@
+# Rich Representations
+
+Custom visual encodings for data that go beyond standard charts and tables.
+
+## Guiding principles
+
+**Visualization matters.** Helping users build custom visual representations
+is one of the highest-impact things the agent can do. A bespoke encoding
+tailored to the task — labeling, batch review, comparing variants — lets
+users *see* their data in ways that tables and numbers never will. marimo
+is an environment where users create their own views, not just consume
+library charts. Help them imagine what's possible, then build it.
+
+**Use the modern web.** Always use the most modern HTML, CSS, and JavaScript
+available. If a feature is supported in every browser, even if only the most
+recent version, use it.
+
+**Prefer compact output.** marimo clips cell output at ~610px and scrolls.
+Avoid hitting that limit; if you need more space, manage your own scrolling
+inside a fixed-height container.
+
+**Keep it thin, make it compose.** A widget is a thin layer over data, not
+an application. One clear purpose, few traitlets, small `_esm`. Build small
+pieces that compose in the notebook — combine with other cells, UI elements,
+and views. Don't over-engineer.
+
+## Decision tree
+
+| Need | Approach |
+|------|----------|
+| Default for any custom output | **anywidget** — even display-only; you get layout control and can add interaction later |
+| Trivial one-off static HTML | `_display_()` or `mo.Html` — only when an anywidget is truly overkill |
+| Single built-in control used as-is (slider, dropdown) | `mo.ui.*` |
+
+When in doubt, build an anywidget.
+
+## anywidget
+
+[anywidget](https://anywidget.dev) bridges Python and JavaScript via
+traitlets. `.tag(sync=True)` makes a traitlet bidirectional — Python sets a
+value → JS sees it; JS calls `model.set()` + `model.save_changes()` →
+Python sees it. `_css` is optional global CSS.
+
+**marimo does not render traditional Jupyter widgets.** Libraries like jscatter,
+ipyvolume, etc. often have a top-level object whose default representation is a
+Jupyter widget (`application/vnd.jupyter.widget-view+json`). marimo cannot
+display these — you need to find the underlying **anywidget** instance, which
+marimo *does* support.
+
+Common pattern: look for a `.widget` attribute on the library object:
+
+```python
+# jscatter example — Scatter is not renderable, but .widget is an anywidget
+scatter = jscatter.Scatter(data=df, x="x", y="y")
+scatter.widget  # <-- use this in the cell output
+```
+
+When unsure, check in the scratchpad:
+
+```python
+import anywidget
+obj = scatter.widget  # or whatever accessor the library provides
+print(isinstance(obj, anywidget.AnyWidget))  # True = marimo can render it
+```
+
+### `_esm` lifecycle
+
+**Render only** (most widgets):
+
+```js
+function render({ model, el }) { /* ... */ }
+export default { render };
+```
+
+**Initialize + render** (shared state across views, one-time setup):
+
+```js
+export default () => {
+  return {
+    initialize({ model }) {
+      // Once per widget instance — timers, connections, shared handlers
+      return () => { /* cleanup */ };
+    },
+    render({ model, el }) {
+      // Once per view — display in 3 cells = 3 renders
+      return () => { /* cleanup DOM listeners */ };
+    }
+  };
+};
+```
+
+- `model.on()` is auto-cleaned when a view is removed
+- DOM `addEventListener` is **not** — clean up with `AbortController`
+
+### Timer example (initialize + render)
+
+`initialize` owns one interval; each `render` view displays it.
+
+```python
+import anywidget
+import traitlets
+
+_TIMER_ESM = """
+export default () => {
+  return {
+    initialize({ model }) {
+      const id = setInterval(() => {
+        if (model.get("running")) {
+          model.set("seconds", model.get("seconds") + 1);
+          model.save_changes();
+        }
+      }, 1000);
+      return () => clearInterval(id);
+    },
+    render({ model, el }) {
+      const controller = new AbortController();
+      const { signal } = controller;
+
+      const span = document.createElement("span");
+      span.style.cssText = "font: 24px monospace;";
+
+      const btn = document.createElement("button");
+      btn.style.cssText = "margin-left: 8px; cursor: pointer;";
+
+      function update() {
+        const s = model.get("seconds");
+        const mm = String(Math.floor(s / 60)).padStart(2, "0");
+        const ss = String(s % 60).padStart(2, "0");
+        span.textContent = `${mm}:${ss}`;
+        btn.textContent = model.get("running") ? "⏸" : "▶";
+      }
+
+      model.on("change:seconds", update);
+      model.on("change:running", update);
+
+      btn.addEventListener("click", () => {
+        model.set("running", !model.get("running"));
+        model.save_changes();
+      }, { signal });
+
+      update();
+      el.append(span, btn);
+      return () => controller.abort();
+    }
+  };
+};
+"""
+
+class Timer(anywidget.AnyWidget):
+    seconds = traitlets.Int(0).tag(sync=True)
+    running = traitlets.Bool(True).tag(sync=True)
+    _esm = _TIMER_ESM
+```
+
+### Composing with the notebook
+
+Widgets become reactive notebook citizens when you bridge a traitlet to
+`mo.state`. This is a two-cell pattern — create the widget and wire up the
+observer in one cell, read the value in another:
+
+```python
+# Cell 1 — widget + observer
+timer = Timer()
+
+get_seconds, set_seconds = mo.state(timer.seconds)
+timer.observe(lambda _: set_seconds(timer.seconds), names=["seconds"])
+
+timer  # display the widget
+```
+
+```python
+# Cell 2 — reacts to changes
+seconds = get_seconds()
+mo.md(f"Timer is at **{seconds}s** — {'running' if seconds > 0 else 'stopped'}")
+```
+
+This pattern is always the same: `mo.state(widget.trait)` for the initial
+value, `.observe()` on the specific trait name, read with the getter in a
+downstream cell. See [Reactive anywidgets](#reactive-anywidgets-in-marimo)
+for the full rules.
+
+### CDN dependencies
+
+Import JS libraries from [esm.sh](https://esm.sh) — no build step:
+
+```js
+import * as d3 from "https://esm.sh/d3@7";
+import { tableFromIPC } from "https://esm.sh/@uwdata/flechette@2";
+```
+
+### DataFrames and binary data
+
+**Prefer reducing data on the Python side.** Aggregate, filter, sample —
+send the widget only what it needs. Most widgets should receive a small,
+pre-processed payload via simple traitlets (lists, dicts). This keeps the
+widget simple and avoids extra dependencies.
+
+**For large tabular data (>2k rows)** where the widget genuinely needs
+row-level access, send Arrow IPC bytes instead of JSON. This adds
+complexity and dependencies, so only reach for it when the data volume
+justifies it.
+
+**Python — serialize:**
+
+```python
+# Polars (native, no pyarrow needed)
+_ipc=df.write_ipc(None).getvalue()
+
+# Any __arrow_c_stream__ source (pandas, narwhals, pyarrow, etc.)
+import io, pyarrow as pa, pyarrow.feather as feather
+
+def to_arrow_ipc(data) -> bytes:
+    table = pa.RecordBatchReader.from_stream(data).read_all()
+    sink = io.BytesIO()
+    feather.write_feather(table, sink, compression="uncompressed")
+    return sink.getvalue()
+```
+
+**JS — deserialize with `@uwdata/flechette`:**
+
+```js
+import { tableFromIPC } from "https://esm.sh/@uwdata/flechette@2";
+const table = tableFromIPC(new Uint8Array(model.get("_ipc").buffer));
+// table.numRows, table.numCols, table.get(i), table.getChild("col_name")
+```
+
+Use `traitlets.Any().tag(sync=True)` for the IPC bytes traitlet.
+
+## Reactive anywidgets in marimo
+
+When an anywidget trait (selection, value, zoom, etc.) should drive a
+downstream marimo cell, use `mo.state()` + `.observe()` on the **specific
+trait**. This is the preferred pattern:
+
+```python
+# In the cell that creates the widget:
+get_selection, set_selection = mo.state(widget.selection)
+widget.observe(
+    lambda _: set_selection(widget.selection),
+    names=["selection"],
+)
+
+# In a downstream cell — re-executes when selection changes:
+selection = get_selection()
+```
+
+Initialize `mo.state()` with the widget's current trait value — not a
+hardcoded default. Read the trait directly off the widget in the lambda.
+Do **not** use `change["new"]` or `allow_self_loops=True`.
+
+### `mo.state` + `.observe()` vs `mo.ui.anywidget()`
+
+Two strategies for reactive anywidgets. Choose one per widget — don't mix them.
+
+| Strategy | Reactivity | Best for |
+|----------|-----------|----------|
+| `mo.state` + `.observe()` | Specific traits you pick | Precision — only named traits trigger downstream cells |
+| `mo.ui.anywidget(widget)` | All synced traits as one `.value` dict | Convenience — observe everything at once |
+
+### Programmatic widget control (scratchpad)
+
+Read widget state or set UI controls from the scratchpad — no clicking:
+
+```python
+print(timer.seconds)    # read
+timer.seconds = 0       # set — frontend updates automatically
+```
+
+`mo.ui.*` elements need `set_ui_element_value`; anywidgets use direct
+assignment.
+
+## `_display_()` protocol
+
+Any object with a `_display_()` method renders richly in marimo. Return
+anything marimo can render — `mo.Html`, `mo.md()`, a chart, a string.
+
+Precedence: `_display_()` > built-in formatters > `_mime_()` > IPython
+`_repr_*_()` methods.
+
+```python
+from dataclasses import dataclass
+import marimo as mo
+
+@dataclass
+class ColorSwatch:
+    colors: list[str]
+
+    def _display_(self):
+        divs = "".join(
+            f'<div style="width:40px;height:40px;background:{c};border-radius:4px;"></div>'
+            for c in self.colors
+        )
+        return mo.Html(f'<div style="display:flex;gap:8px;">{divs}</div>')
+```
+
+For inline `<script>` tags, use `document.currentScript.previousElementSibling`
+to scope to the element — never hardcode IDs (breaks with multiple instances).
+
+## Minimize CLS (Cumulative Layout Shift)
+
+Use `min-height` or `aspect-ratio` on the outer container so the widget
+reserves space before content loads or when toggling between states.

--- a/.agents/skills/marimo-pair/renovate.json
+++ b/.agents/skills/marimo-pair/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>marimo-team/.github:renovate-config"
+  ]
+}

--- a/.agents/skills/marimo-pair/scripts/discover-servers.sh
+++ b/.agents/skills/marimo-pair/scripts/discover-servers.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# List running marimo instances from the server registry.
+# Cleans up stale entries (dead PIDs) and outputs live servers as JSON.
+# No marimo installation required.
+set -euo pipefail
+
+# Locate the servers directory
+is_windows=false
+if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* ]]; then
+  is_windows=true
+  servers_dir="$HOME/.marimo/servers"
+else
+  servers_dir="${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
+fi
+
+if [[ ! -d "$servers_dir" ]]; then
+  echo "[]"
+  exit 0
+fi
+
+# Liveness check. On POSIX, `kill -0 $pid` is cheap and reliable. On Windows
+# (Git Bash/MSYS2) `kill` operates on Cygwin PIDs, not the native Windows PIDs
+# marimo writes, so fall back to an HTTP probe against marimo's /health.
+check_live() {
+  local f="$1"
+  if [[ "$is_windows" == false ]]; then
+    local pid
+    pid=$(jq -r '.pid' "$f" 2>/dev/null) || return 1
+    kill -0 "$pid" 2>/dev/null
+  else
+    local host port base_url
+    host=$(jq -r '.host' "$f" 2>/dev/null) || return 1
+    port=$(jq -r '.port' "$f" 2>/dev/null) || return 1
+    base_url=$(jq -r '.base_url' "$f" 2>/dev/null) || return 1
+    curl -sf --max-time 1 "http://${host}:${port}${base_url}/health" >/dev/null 2>&1
+  fi
+}
+
+results="[]"
+for f in "$servers_dir"/*.json; do
+  [[ -e "$f" ]] || continue
+
+  if ! check_live "$f"; then
+    # On Windows the HTTP probe can fail transiently (slow start, busy server),
+    # so keep the entry; only POSIX `kill -0` is reliable enough to delete on.
+    [[ "$is_windows" == false ]] && rm -f "$f"
+    continue
+  fi
+
+  entry=$(jq '.' "$f" 2>/dev/null) || continue
+  results=$(echo "$results" | jq --argjson e "$entry" '. + [$e]')
+done
+
+echo "$results" | jq .

--- a/.agents/skills/marimo-pair/scripts/execute-code.sh
+++ b/.agents/skills/marimo-pair/scripts/execute-code.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Execute code in a running marimo session's scratchpad.
+# No marimo installation required — talks directly to the HTTP API.
+# Usage:
+#   execute-code.sh [--port PORT] [--session ID] -c "code"   # inline code
+#   execute-code.sh [--port PORT] [--session ID] script.py    # code from file
+#   execute-code.sh [--port PORT] [--session ID] <<< "code"   # stdin (here-string)
+#   execute-code.sh [--port PORT] [--session ID] <<'EOF'       # stdin (heredoc)
+#     code
+#   EOF
+#   execute-code.sh --url URL [--session ID] -c "code"        # skip discovery, hit URL directly
+#
+# Auth: set MARIMO_TOKEN env var (preferred) or pass --token TOKEN (visible in ps).
+set -euo pipefail
+
+# Optional eval logging: set EXECUTE_CODE_LOG to a file path to record each call
+if [[ -n "${EXECUTE_CODE_LOG:-}" ]]; then
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$EXECUTE_CODE_LOG"
+fi
+
+port=""
+code=""
+url=""
+token="${MARIMO_TOKEN:-}"
+session=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)    port="$2"; shift 2 ;;
+    --url)     url="$2"; shift 2 ;;
+    --token)   token="$2"; shift 2 ;;
+    --session) session="$2"; shift 2 ;;
+    -c)        code="$2"; shift 2 ;;
+    -*)      echo "Unknown option: $1" >&2; exit 1 ;;
+    *)       break ;;
+  esac
+done
+
+if [[ -n "$code" ]]; then
+  : # set via -c
+elif [[ $# -gt 0 ]]; then
+  code=$(cat "$1")
+elif [[ ! -t 0 ]]; then
+  code=$(cat)
+else
+  echo "Usage: execute-code.sh [--port PORT | --url URL] -c 'code'" >&2
+  echo "       execute-code.sh [--port PORT | --url URL] script.py" >&2
+  echo "       echo 'code' | execute-code.sh [--port PORT | --url URL]" >&2
+  echo "Auth:  set MARIMO_TOKEN env var (preferred) or pass --token TOKEN" >&2
+  exit 1
+fi
+
+if [[ -n "$url" ]]; then
+  base="${url%/}"
+  # Warn when connecting to a non-local server (data exfiltration risk)
+  url_host="${url#*://}"
+  url_host="${url_host%%[:/]*}"
+  case "$url_host" in
+    localhost|127.0.0.1|::1|0.0.0.0) ;;
+    *) echo "Warning: connecting to non-local server '${url_host}'. Ensure this is trusted." >&2 ;;
+  esac
+else
+  # Locate the servers directory
+  is_windows=false
+  if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* ]]; then
+    is_windows=true
+    servers_dir="$HOME/.marimo/servers"
+  else
+    servers_dir="${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
+  fi
+
+  # Liveness check. On POSIX, `kill -0 $pid` is cheap and reliable. On Windows
+  # (Git Bash/MSYS2) `kill` operates on Cygwin PIDs, not the native Windows PIDs
+  # marimo writes, so fall back to an HTTP probe against marimo's /health.
+  check_live() {
+    local f="$1"
+    if [[ "$is_windows" == false ]]; then
+      local pid
+      pid=$(jq -r '.pid' "$f" 2>/dev/null) || return 1
+      kill -0 "$pid" 2>/dev/null
+    else
+      local host port base_url
+      host=$(jq -r '.host' "$f" 2>/dev/null) || return 1
+      port=$(jq -r '.port' "$f" 2>/dev/null) || return 1
+      base_url=$(jq -r '.base_url' "$f" 2>/dev/null) || return 1
+      curl -sf --max-time 1 "http://${host}:${port}${base_url}/health" >/dev/null 2>&1
+    fi
+  }
+
+  # Find a live registry entry
+  entry=""
+  count=0
+  for f in "$servers_dir"/*.json; do
+    [[ -e "$f" ]] || continue
+
+    if ! check_live "$f"; then
+      # On Windows the HTTP probe can fail transiently (slow start, busy server),
+      # so keep the entry; only POSIX `kill -0` is reliable enough to delete on.
+      [[ "$is_windows" == false ]] && rm -f "$f"
+      continue
+    fi
+
+    e=$(cat "$f")
+
+    if [[ -n "$port" ]]; then
+      e_port=$(echo "$e" | jq -r '.port')
+      if [[ "$e_port" == "$port" ]]; then
+        entry="$e"
+        count=1
+        break
+      fi
+      continue
+    fi
+
+    entry="$e"
+    count=$((count + 1))
+  done
+
+  if [[ $count -eq 0 ]]; then
+    echo "No running marimo instances found." >&2
+    exit 1
+  fi
+
+  if [[ $count -gt 1 ]]; then
+    echo "Multiple instances found. Use --port to specify:" >&2
+    for f in "$servers_dir"/*.json; do
+      [[ -e "$f" ]] || continue
+      check_live "$f" || continue
+      jq -r '.server_id' "$f" >&2
+    done
+    exit 1
+  fi
+
+  host=$(echo "$entry" | jq -r '.host')
+  e_port=$(echo "$entry" | jq -r '.port')
+  base_url=$(echo "$entry" | jq -r '.base_url')
+  base="http://${host}:${e_port}${base_url}"
+fi
+
+# Build optional auth header
+auth_args=()
+if [[ -n "$token" ]]; then
+  auth_args+=(-H "Authorization: Bearer ${token}")
+fi
+
+# Discover session ID
+if [[ -n "$session" ]]; then
+  session_id="$session"
+else
+  sessions_resp=$(curl -sf "${auth_args[@]+"${auth_args[@]}"}" "${base}/api/sessions") || {
+    echo "Failed to connect to marimo server at ${base}" >&2
+    exit 1
+  }
+
+  session_ids=$(echo "$sessions_resp" | jq -r 'keys[]')
+
+  if [[ -z "$session_ids" ]]; then
+    echo "No active sessions on the server. Make sure a notebook is open in the browser." >&2
+    exit 1
+  fi
+
+  session_count=$(echo "$session_ids" | wc -l | tr -d ' ')
+
+  if [[ $session_count -gt 1 ]]; then
+    echo "Multiple sessions on server. Cannot auto-select:" >&2
+    echo "$sessions_resp" | jq -r 'to_entries[] | "\(.key)  \(.value.filename // "")"' >&2
+    exit 1
+  fi
+
+  session_id=$(echo "$session_ids" | head -1)
+fi
+
+# Execute code via SSE stream
+# Events: stdout/stderr stream as JSON {"data":"..."}, done is final result.
+exit_code=0
+current_event=""
+done_received=false
+while IFS= read -r line && [[ "$done_received" == false ]]; do
+  case "$line" in
+    event:*)
+      current_event="${line#event: }"
+      ;;
+    data:*)
+      payload="${line#data: }"
+      case "$current_event" in
+        stdout)
+          echo "$payload" | jq -jr '.data'
+          ;;
+        stderr)
+          echo "$payload" | jq -jr '.data' >&2
+          ;;
+        done)
+          if echo "$payload" | jq -e '.success == false' >/dev/null 2>&1; then
+            echo "$payload" | jq -r '.error.msg' >&2
+            exit_code=1
+          else
+            echo "$payload" | jq -r '.output.data // empty'
+          fi
+          done_received=true
+          ;;
+      esac
+      ;;
+  esac
+done < <(curl -sN -X POST "${base}/api/kernel/execute" \
+  -H "Content-Type: application/json" \
+  -H "Marimo-Session-Id: ${session_id}" \
+  ${auth_args[@]+"${auth_args[@]}"} \
+  -d "$(jq -n --arg c "$code" '{code: $c}')" \
+)
+
+exit "$exit_code"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ This ensures that the most important and frequently needed guidance is easily ac
 - 2026-03-24: Keep `uv`-based CI testing in `.github/workflows/pr-tests.yaml`, but do not keep `uv.lock` in the repository.
 - 2026-03-28: Do not add pytest coverage for standalone demos (e.g. FastAPI + HTMX examples under `docs/examples/`). Tests target library and CLI behavior; demos are exercised manually or via documentation.
 - 2026-03-28: Prefer **not** running the full test suite locally (`pixi run test`, etc.); let **GitHub Actions CI** validate tests. Agents should skip long local pytest runs unless the user explicitly asks for them.
+- 2026-04-30: **Marimo notebooks — no disk edits by agents.** Do not use Write, StrReplace, apply_patch, or other repo edit tools on Marimo notebook `.py` files to change cells or notebook structure. Mutate notebooks only via `marimo._code_mode` in the **running** notebook kernel (see `.agents/skills/marimo-pair/` and `scripts/execute-code.sh`). If no session is running, ask the user to start `marimo edit` (or open the notebook) before applying changes.
 
 ## Project Overview
 
@@ -85,8 +86,11 @@ without the "pixi run" prefix. Use `markdownlint filename.md` instead of
 `pixi run markdownlint filename.md`. If markdownlint is not available, install
 it using `pixi global install markdownlint`.
 
-**Notebooks**: All notebooks in this repository are Marimo notebooks. When
-agents create or edit notebooks, they must run `uvx marimo check
+**Notebooks**: All notebooks in this repository are Marimo notebooks.
+
+**CRITICAL — agent edits vs disk**: LLM agents must **not** edit Marimo notebook `.py` files on disk (no Write / StrReplace / apply_patch to notebook sources for cell content or structure). The running marimo kernel owns the notebook; use **`marimo._code_mode`** through an active session instead (marimo-pair skill: `bash .agents/skills/marimo-pair/scripts/execute-code.sh` with a heredoc, `--url`, and `--session` as needed). Humans may still edit notebook files locally with editor workflows; this rule targets **automated agent** changes.
+
+When agents create or edit notebooks via normal workflows, they must run `uvx marimo check
 <path/to/notebook.py>` to validate the notebook and fix any issues raised by
 the check command. Always run `uvx marimo check` on notebooks before considering
 them complete - this catches critical errors like duplicate variable definitions
@@ -100,7 +104,7 @@ in `docs/how-to/` that are converted to markdown for documentation:
 
 1. Run the conversion script: `pixi run python scripts/convert_marimo_to_markdown.py`
 2. Run markdownlint on the generated files: `markdownlint docs/how-to/*.md`
-3. Fix any linting errors by editing the source `.py` files (not the generated `.md` files)
+3. Fix any linting errors by editing the source `.py` files (not the generated `.md` files). **Agents** should follow the **CRITICAL — agent edits vs disk** rule above: prefer `marimo._code_mode` when a session is active rather than patching notebook `.py` files on disk.
 4. Common fixes needed:
    - Add blank lines before lists (MD032)
    - Change H1 headings to H2 to avoid multiple top-level headings (MD025)

--- a/docs/how-to/agent-mcp-tools.md
+++ b/docs/how-to/agent-mcp-tools.md
@@ -1,0 +1,97 @@
+# Use MCP tools with AgentBot
+
+LlamaBot can merge **Python tools** (``@tool`` functions) with tools discovered from **MCP servers**
+(stdio subprocesses or remote HTTP / SSE / streamable HTTP endpoints) using FastMCP's client.
+
+## When to use this
+
+- You already expose capabilities as an MCP server and want the same tools inside ``AgentBot``
+  or ``ToolBot`` without rewriting them as Python callables.
+- You mix a few in-repo Python tools with shared MCP-hosted tools (e.g. org-wide servers).
+
+## Constructor parameters
+
+- ``mcp_servers``: list of :class:`~llamabot.mcp.specs.MCPServerSpec`
+- ``mcp_options``: optional :class:`~llamabot.mcp.specs.MCPIntegrationOptions`
+
+MCP tools are registered **after** your Python ``tools=`` list (defaults from ``DEFAULT_TOOLS`` stay first).
+
+## Lifespan
+
+Each MCP server runs a **persistent session** on a background thread until you call:
+
+- ``AgentBot.close_mcp()`` or ``AsyncAgentBot.close_mcp()``
+- ``ToolBot.close_mcp()`` when ``ToolBot`` was constructed with ``mcp_servers=``
+
+Call one of these when the bot is discarded (especially in long-lived apps) so subprocesses and HTTP sessions shut down cleanly.
+
+## Example (in-process server for tests)
+
+```python
+from fastmcp import FastMCP
+
+from llamabot.bot.agentbot import AgentBot
+from llamabot.components.tools import tool
+from llamabot.mcp.specs import MCPServerSpec, MCPIntegrationOptions, MCPStartupMode
+
+mcp = FastMCP("demo")
+
+@mcp.tool()
+def greet(name: str) -> str:
+    """Say hello."""
+    return f"Hello, {name}!"
+
+@tool
+def double(x: int) -> int:
+    """Double an integer."""
+    return x * 2
+
+bot = AgentBot(
+    tools=[double],
+    mcp_servers=[MCPServerSpec(name="demo", transport="inproc", fastmcp=mcp)],
+    mcp_options=MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT),
+)
+
+try:
+    bot("Use greet via MCP with name Ada")  # model selects demo__greet
+finally:
+    bot.close_mcp()
+```
+
+## Remote URL server
+
+```python
+from llamabot.mcp.specs import MCPServerSpec
+
+MCPServerSpec(
+    name="remote",
+    transport="http",
+    url="http://localhost:8080/mcp",
+    headers={"Authorization": "Bearer TOKEN"},
+)
+```
+
+For SSE endpoints, set ``transport="sse"`` (or rely on FastMCP URL path inference when using ``transport="http"``).
+
+## Stdio server (same shape as Cursor MCP config)
+
+```python
+MCPServerSpec(
+    name="docs",
+    transport="stdio",
+    command="uvx",
+    args=["--with", "llamabot[all]", "llamabot", "mcp", "launch"],
+    env={},
+)
+```
+
+## Tool naming and filtering
+
+- Remote tool ``echo`` on server ``srv`` becomes Python symbol ``srv__echo`` by default (separator from ``MCPIntegrationOptions.tool_namespace_sep``).
+- JSON Schema property names that are not valid Python identifiers are sanitized for the model; wire names are preserved when calling MCP.
+- ``allow_tools`` / ``deny_tools`` on :class:`~llamabot.mcp.specs.MCPIntegrationOptions` filter by **prefixed** names (e.g. ``srv__echo``).
+
+## Startup modes
+
+- ``MCPStartupMode.BEST_EFFORT`` (default): failed servers are skipped; check ``MCPClientManager.failures`` if you construct the manager yourself.
+- ``MCPStartupMode.STRICT``: any connection or discovery failure raises during bot construction.

--- a/docs/how-to/agent-mcp-tools.md
+++ b/docs/how-to/agent-mcp-tools.md
@@ -11,7 +11,7 @@ LlamaBot can merge **Python tools** (``@tool`` functions) with tools discovered 
 
 ## Constructor parameters
 
-- ``mcp_servers``: list of :class:`~llamabot.mcp.specs.MCPServerSpec`
+- ``mcp_servers``: list of :class:`~llamabot.mcp.specs.MCPServerConfig`
 - ``mcp_options``: optional :class:`~llamabot.mcp.specs.MCPIntegrationOptions`
 
 MCP tools are registered **after** your Python ``tools=`` list (defaults from ``DEFAULT_TOOLS`` stay first).
@@ -32,7 +32,7 @@ from fastmcp import FastMCP
 
 from llamabot.bot.agentbot import AgentBot
 from llamabot.components.tools import tool
-from llamabot.mcp.specs import MCPServerSpec, MCPIntegrationOptions, MCPStartupMode
+from llamabot.mcp.specs import MCPServerConfig, MCPIntegrationOptions, MCPStartupMode
 
 mcp = FastMCP("demo")
 
@@ -48,7 +48,7 @@ def double(x: int) -> int:
 
 bot = AgentBot(
     tools=[double],
-    mcp_servers=[MCPServerSpec(name="demo", transport="inproc", fastmcp=mcp)],
+    mcp_servers=[MCPServerConfig(name="demo", transport="inproc", fastmcp=mcp)],
     mcp_options=MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT),
 )
 
@@ -61,9 +61,9 @@ finally:
 ## Remote URL server
 
 ```python
-from llamabot.mcp.specs import MCPServerSpec
+from llamabot.mcp.specs import MCPServerConfig
 
-MCPServerSpec(
+MCPServerConfig(
     name="remote",
     transport="http",
     url="http://localhost:8080/mcp",
@@ -76,7 +76,7 @@ For SSE endpoints, set ``transport="sse"`` (or rely on FastMCP URL path inferenc
 ## Stdio server (same shape as Cursor MCP config)
 
 ```python
-MCPServerSpec(
+MCPServerConfig(
     name="docs",
     transport="stdio",
     command="uvx",

--- a/docs/reference/bots/agentbot.md
+++ b/docs/reference/bots/agentbot.md
@@ -23,7 +23,9 @@ def __init__(
     decide_node: Optional[DecideNode] = None,
     system_prompt: Optional[str] = None,
     model_name: str = "gpt-4o-mini",
-    chat_memory: Optional[ChatMemory] = None,
+    max_iterations: Optional[int] = None,
+    mcp_servers: Optional[List[MCPServerSpec]] = None,
+    mcp_options: Optional[MCPIntegrationOptions] = None,
     **completion_kwargs,
 )
 ```
@@ -41,6 +43,12 @@ def __init__(
 - **chat_memory** (`Optional[ChatMemory]`, default: `None`): Chat memory component for maintaining conversation context.
 
 - **completion_kwargs**: Additional keyword arguments to pass to the completion function.
+
+- **mcp_servers**: Optional list of ``MCPServerSpec``; default ``None``. MCP tools are merged after Python ``tools``. See [AgentBot with MCP tools](../../how-to/agent-mcp-tools.md).
+
+- **mcp_options**: Optional ``MCPIntegrationOptions``; default ``None``. Startup mode, timeouts, allow/deny lists, and tool namespace separator.
+
+When using MCP servers, call ``bot.close_mcp()`` when finished to release subprocess / HTTP sessions.
 
 ### Tool Requirements
 

--- a/docs/reference/bots/agentbot.md
+++ b/docs/reference/bots/agentbot.md
@@ -24,7 +24,7 @@ def __init__(
     system_prompt: Optional[str] = None,
     model_name: str = "gpt-4o-mini",
     max_iterations: Optional[int] = None,
-    mcp_servers: Optional[List[MCPServerSpec]] = None,
+    mcp_servers: Optional[List[MCPServerConfig]] = None,
     mcp_options: Optional[MCPIntegrationOptions] = None,
     **completion_kwargs,
 )
@@ -44,7 +44,7 @@ def __init__(
 
 - **completion_kwargs**: Additional keyword arguments to pass to the completion function.
 
-- **mcp_servers**: Optional list of ``MCPServerSpec``; default ``None``. MCP tools are merged after Python ``tools``. See [AgentBot with MCP tools](../../how-to/agent-mcp-tools.md).
+- **mcp_servers**: Optional list of ``MCPServerConfig``; default ``None``. MCP tools are merged after Python ``tools``. See [AgentBot with MCP tools](../../how-to/agent-mcp-tools.md).
 
 - **mcp_options**: Optional ``MCPIntegrationOptions``; default ``None``. Startup mode, timeouts, allow/deny lists, and tool namespace separator.
 

--- a/llamabot/bot/agentbot.py
+++ b/llamabot/bot/agentbot.py
@@ -13,7 +13,7 @@ from pocketflow import Flow, Node
 from llamabot.components.pocketflow import DecideNode
 from llamabot.components.tools import DEFAULT_TOOLS
 from llamabot.mcp.manager import MCPClientManager
-from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerConfig
 
 
 def _validate_tools(tools: List[Callable]) -> None:
@@ -123,7 +123,7 @@ class AgentBot:
         system_prompt: Optional[str] = None,
         model_name: str = "gpt-4.1",
         max_iterations: Optional[int] = None,
-        mcp_servers: Optional[List[MCPServerSpec]] = None,
+        mcp_servers: Optional[List[MCPServerConfig]] = None,
         mcp_options: Optional[MCPIntegrationOptions] = None,
         **completion_kwargs,
     ):

--- a/llamabot/bot/agentbot.py
+++ b/llamabot/bot/agentbot.py
@@ -12,6 +12,8 @@ from pocketflow import Flow, Node
 
 from llamabot.components.pocketflow import DecideNode
 from llamabot.components.tools import DEFAULT_TOOLS
+from llamabot.mcp.manager import MCPClientManager
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec
 
 
 def _validate_tools(tools: List[Callable]) -> None:
@@ -70,6 +72,10 @@ class AgentBot:
     a decision node that uses ToolBot to select tools and executes them through
     a PocketFlow graph.
 
+    Optionally pass ``mcp_servers`` / ``mcp_options`` to attach FastMCP-discovered
+    tools from stdio or HTTP/SSE servers (see :mod:`llamabot.mcp`). Call
+    :meth:`close_mcp` when the bot is discarded.
+
     **Tool Requirements:**
     Tools must be decorated with `@tool` before being passed to AgentBot. Example:
 
@@ -105,6 +111,8 @@ class AgentBot:
         If None, no limit is enforced. Defaults to None.
     :param completion_kwargs: Additional keyword arguments to pass to the
         completion function of `litellm` (e.g., `api_base`, `api_key`).
+    :param mcp_servers: Optional MCP servers whose tools are merged after Python tools.
+    :param mcp_options: Options for MCP startup and tool namespacing (see :class:`~llamabot.mcp.specs.MCPIntegrationOptions`).
     :raises ValueError: If any tool is not properly decorated with @tool
     """
 
@@ -115,14 +123,23 @@ class AgentBot:
         system_prompt: Optional[str] = None,
         model_name: str = "gpt-4.1",
         max_iterations: Optional[int] = None,
+        mcp_servers: Optional[List[MCPServerSpec]] = None,
+        mcp_options: Optional[MCPIntegrationOptions] = None,
         **completion_kwargs,
     ):
+        self._mcp_manager: MCPClientManager | None = None
+        mcp_tool_list: List[Callable] = []
+        if mcp_servers:
+            self._mcp_manager = MCPClientManager(mcp_servers, mcp_options)
+            self._mcp_manager.start()
+            mcp_tool_list = self._mcp_manager.llamabot_tools()
+
         # Validate that all user-provided tools are properly decorated
         _validate_tools(tools)
+        _validate_tools(mcp_tool_list)
 
-        # Combine default and user-provided tools
-        # Default tools are already configured for AgentBot
-        all_tools = list(DEFAULT_TOOLS) + tools
+        # Combine default, user Python tools, and MCP-backed tools
+        all_tools = list(DEFAULT_TOOLS) + list(tools) + mcp_tool_list
 
         self.tools = all_tools
 
@@ -180,6 +197,15 @@ class AgentBot:
 
         # Track all trace_ids from this bot instance for span visualization
         self._trace_ids = []
+
+    def close_mcp(self) -> None:
+        """Close MCP sessions opened via ``mcp_servers`` constructor arguments.
+
+        Safe to call multiple times. Does not affect Python-only tools.
+        """
+        if self._mcp_manager is not None:
+            self._mcp_manager.close()
+            self._mcp_manager = None
 
     def __call__(self, query: str, globals_dict: Optional[dict] = None):
         """Execute the agent with a query.

--- a/llamabot/bot/async_agentbot.py
+++ b/llamabot/bot/async_agentbot.py
@@ -25,6 +25,8 @@ from pocketflow import AsyncFlow, AsyncNode, Node
 from llamabot.bot.agentbot import _validate_tools
 from llamabot.components.pocketflow import DecideNode
 from llamabot.components.tools import DEFAULT_TOOLS
+from llamabot.mcp.manager import MCPClientManager
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec
 
 
 def _tool_routing_name(tool_node: Callable) -> str:
@@ -118,6 +120,9 @@ class AsyncAgentBot:
 
     Graph topology matches :class:`~llamabot.bot.agentbot.AgentBot`; only the flow runner
     and node wrappers differ. Visualization and span APIs mirror :class:`AgentBot`.
+
+    Supports the same ``mcp_servers`` / ``mcp_options`` constructor arguments as
+    :class:`~llamabot.bot.agentbot.AgentBot`; use :meth:`close_mcp` for cleanup.
     """
 
     def __init__(
@@ -127,11 +132,21 @@ class AsyncAgentBot:
         system_prompt: Optional[str] = None,
         model_name: str = "gpt-4.1",
         max_iterations: Optional[int] = None,
+        mcp_servers: Optional[List[MCPServerSpec]] = None,
+        mcp_options: Optional[MCPIntegrationOptions] = None,
         **completion_kwargs,
     ) -> None:
-        _validate_tools(tools)
+        self._mcp_manager: MCPClientManager | None = None
+        mcp_tool_list: List[Callable] = []
+        if mcp_servers:
+            self._mcp_manager = MCPClientManager(mcp_servers, mcp_options)
+            self._mcp_manager.start()
+            mcp_tool_list = self._mcp_manager.llamabot_tools()
 
-        all_tools = list(DEFAULT_TOOLS) + tools
+        _validate_tools(tools)
+        _validate_tools(mcp_tool_list)
+
+        all_tools = list(DEFAULT_TOOLS) + tools + mcp_tool_list
         self.tools = all_tools
 
         if decide_node is None:
@@ -173,6 +188,12 @@ class AsyncAgentBot:
         self.flow = AsyncFlow(start=async_decide)
         self.shared: dict = dict(memory=[], globals_dict={})
         self._trace_ids: list = []
+
+    def close_mcp(self) -> None:
+        """Close MCP sessions opened via ``mcp_servers`` (mirror :meth:`~llamabot.bot.agentbot.AgentBot.close_mcp`)."""
+        if self._mcp_manager is not None:
+            self._mcp_manager.close()
+            self._mcp_manager = None
 
     async def arun(self, query: str, globals_dict: Optional[dict] = None) -> object:
         """Execute the agent asynchronously via :meth:`AsyncFlow.run_async`.

--- a/llamabot/bot/async_agentbot.py
+++ b/llamabot/bot/async_agentbot.py
@@ -26,7 +26,7 @@ from llamabot.bot.agentbot import _validate_tools
 from llamabot.components.pocketflow import DecideNode
 from llamabot.components.tools import DEFAULT_TOOLS
 from llamabot.mcp.manager import MCPClientManager
-from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerConfig
 
 
 def _tool_routing_name(tool_node: Callable) -> str:
@@ -132,7 +132,7 @@ class AsyncAgentBot:
         system_prompt: Optional[str] = None,
         model_name: str = "gpt-4.1",
         max_iterations: Optional[int] = None,
-        mcp_servers: Optional[List[MCPServerSpec]] = None,
+        mcp_servers: Optional[List[MCPServerConfig]] = None,
         mcp_options: Optional[MCPIntegrationOptions] = None,
         **completion_kwargs,
     ) -> None:

--- a/llamabot/bot/toolbot.py
+++ b/llamabot/bot/toolbot.py
@@ -16,6 +16,8 @@ from llamabot.bot.simplebot import (
 from llamabot.components.chat_memory import ChatMemory
 from llamabot.components.messages import AIMessage, BaseMessage
 from llamabot.components.tools import DEFAULT_TOOLS
+from llamabot.mcp.manager import MCPClientManager
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec
 from llamabot.prompt_manager import prompt
 
 
@@ -81,6 +83,8 @@ class ToolBot(SimpleBot):
     :param tools: Optional list of additional tools to include
     :param chat_memory: Chat memory component for context retrieval
     :param completion_kwargs: Additional keyword arguments for completion
+    :param mcp_servers: Optional MCP servers whose tools are appended after defaults.
+    :param mcp_options: MCP integration options (timeouts, allow/deny lists).
     """
 
     def __init__(
@@ -89,6 +93,8 @@ class ToolBot(SimpleBot):
         model_name: str,
         tools: Optional[List[Callable]] = None,
         chat_memory: Optional[ChatMemory] = None,
+        mcp_servers: Optional[List[MCPServerSpec]] = None,
+        mcp_options: Optional[MCPIntegrationOptions] = None,
         **completion_kwargs,
     ):
         super().__init__(
@@ -96,6 +102,13 @@ class ToolBot(SimpleBot):
             model_name=model_name,
             **completion_kwargs,
         )
+
+        self._mcp_manager: MCPClientManager | None = None
+        mcp_tool_list: List[Callable] = []
+        if mcp_servers:
+            self._mcp_manager = MCPClientManager(mcp_servers, mcp_options)
+            self._mcp_manager.start()
+            mcp_tool_list = self._mcp_manager.llamabot_tools()
 
         # Use tools as-is if provided (they already include DEFAULT_TOOLS from AgentBot)
         # Only add DEFAULT_TOOLS if no tools are provided or if DEFAULT_TOOLS aren't already present
@@ -114,9 +127,16 @@ class ToolBot(SimpleBot):
                 # DEFAULT_TOOLS not included (direct ToolBot call), add them
                 all_tools = DEFAULT_TOOLS + tools
 
+        all_tools = list(all_tools) + mcp_tool_list
         self.tools = [f.json_schema for f in all_tools]
         self.name_to_tool_map = {f.__name__: f for f in all_tools}
         self.chat_memory = chat_memory or ChatMemory()
+
+    def close_mcp(self) -> None:
+        """Close MCP sessions opened via ``mcp_servers``."""
+        if self._mcp_manager is not None:
+            self._mcp_manager.close()
+            self._mcp_manager = None
 
     def compose_tool_messages(
         self,

--- a/llamabot/bot/toolbot.py
+++ b/llamabot/bot/toolbot.py
@@ -17,7 +17,7 @@ from llamabot.components.chat_memory import ChatMemory
 from llamabot.components.messages import AIMessage, BaseMessage
 from llamabot.components.tools import DEFAULT_TOOLS
 from llamabot.mcp.manager import MCPClientManager
-from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerConfig
 from llamabot.prompt_manager import prompt
 
 
@@ -93,7 +93,7 @@ class ToolBot(SimpleBot):
         model_name: str,
         tools: Optional[List[Callable]] = None,
         chat_memory: Optional[ChatMemory] = None,
-        mcp_servers: Optional[List[MCPServerSpec]] = None,
+        mcp_servers: Optional[List[MCPServerConfig]] = None,
         mcp_options: Optional[MCPIntegrationOptions] = None,
         **completion_kwargs,
     ):

--- a/llamabot/components/pocketflow/nodes.py
+++ b/llamabot/components/pocketflow/nodes.py
@@ -12,6 +12,23 @@ from llamabot.recorder import Span, get_current_span, is_span_recording_enabled
 DECIDE_NODE_ACTION = "decide"
 
 
+def format_result_for_history(result):
+    """Create a compact, JSON-safe representation of a tool result.
+
+    :param result: Tool execution result.
+    :return: JSON-serializable primitive or stringified representation.
+    """
+    if isinstance(result, (str, int, float, bool)) or result is None:
+        return result
+    if isinstance(result, list):
+        return [format_result_for_history(item) for item in result]
+    if isinstance(result, dict):
+        return {
+            str(key): format_result_for_history(value) for key, value in result.items()
+        }
+    return str(result)
+
+
 def nodeify(func=None, *, loopback_name: str = DECIDE_NODE_ACTION):
     """Decorator to turn a function into a PocketFlow Node.
 
@@ -151,6 +168,18 @@ def nodeify(func=None, *, loopback_name: str = DECIDE_NODE_ACTION):
                     shared["memory"].append(success_msg)
                 else:
                     shared["memory"].append(exec_res)
+
+                execution_history = shared.setdefault("execution_history", [])
+                execution_history.append(
+                    {
+                        "tool_name": self.func.__name__,
+                        "args": prep_result.get("func_call", {}),
+                        "result": format_result_for_history(exec_res),
+                        "was_cached": False,
+                    }
+                )
+                if len(execution_history) > 20:
+                    shared["execution_history"] = execution_history[-20:]
 
                 if self.loopback_name is None:
                     # For terminal nodes, store result in shared state and return None
@@ -447,35 +476,55 @@ class DecideNode(Node):
         else:
             bot.tool_choice = "required"
 
-        # Get tool calls from ToolBot
-        tool_calls = bot(prep_res["memory"])
+        queued_tool_calls = prep_res.get("pending_tool_calls", [])
 
-        # Handle case where no tool calls are returned
-        if not tool_calls:
-            error_msg = (
-                f"No tool calls returned from ToolBot. Model: {self.model_name}. "
+        if queued_tool_calls:
+            next_tool_call = queued_tool_calls.pop(0)
+            prep_res["pending_tool_calls"] = queued_tool_calls
+            func_name = next_tool_call["name"]
+            func_args_json = next_tool_call["arguments"]
+            logger.info(
+                "DecideNode continuing queued tool call: "
+                f"{func_name} ({len(queued_tool_calls)} queued after this)"
             )
-            if self.model_name.startswith("ollama") or self.model_name.startswith(
-                "ollama_chat"
-            ):
-                error_msg += (
-                    "Ollama models don't support tool_choice='required', so tool calls are optional. "
-                    "Ensure your system prompt explicitly requires tool calls and that the model "
-                    "supports function calling."
-                )
-            else:
-                error_msg += (
-                    "This may indicate the model doesn't support tool_choice='required'. "
-                    "Check the system prompt and ensure it explicitly requires tool calls."
-                )
-            raise ValueError(error_msg)
+        else:
+            # Get tool calls from ToolBot
+            tool_calls = bot(
+                prep_res["memory"],
+                execution_history=prep_res.get("execution_history"),
+            )
 
-        # Get the first tool call (ToolBot typically returns one)
-        tool_call = tool_calls[0]
+            # Handle case where no tool calls are returned
+            if not tool_calls:
+                error_msg = (
+                    f"No tool calls returned from ToolBot. Model: {self.model_name}. "
+                )
+                if self.model_name.startswith("ollama") or self.model_name.startswith(
+                    "ollama_chat"
+                ):
+                    error_msg += (
+                        "Ollama models don't support tool_choice='required', so tool calls are optional. "
+                        "Ensure your system prompt explicitly requires tool calls and that the model "
+                        "supports function calling."
+                    )
+                else:
+                    error_msg += (
+                        "This may indicate the model doesn't support tool_choice='required'. "
+                        "Check the system prompt and ensure it explicitly requires tool calls."
+                    )
+                raise ValueError(error_msg)
 
-        # Extract function name and arguments
-        func_name = tool_call.function.name
-        func_args_json = tool_call.function.arguments
+            normalized_tool_calls = [
+                {
+                    "name": tool_call.function.name,
+                    "arguments": tool_call.function.arguments,
+                }
+                for tool_call in tool_calls
+            ]
+            next_tool_call = normalized_tool_calls.pop(0)
+            prep_res["pending_tool_calls"] = normalized_tool_calls
+            func_name = next_tool_call["name"]
+            func_args_json = next_tool_call["arguments"]
 
         # Log to span if available
         if span_obj:
@@ -580,31 +629,53 @@ class DecideNode(Node):
         else:
             bot.tool_choice = "required"
 
-        tool_calls = await bot(prep_res["memory"])
+        queued_tool_calls = prep_res.get("pending_tool_calls", [])
 
-        if not tool_calls:
-            error_msg = (
-                f"No tool calls returned from the model. Model: {self.model_name}. "
+        if queued_tool_calls:
+            next_tool_call = queued_tool_calls.pop(0)
+            prep_res["pending_tool_calls"] = queued_tool_calls
+            func_name = next_tool_call["name"]
+            func_args_json = next_tool_call["arguments"]
+            logger.info(
+                "DecideNode continuing queued tool call: "
+                f"{func_name} ({len(queued_tool_calls)} queued after this)"
             )
-            if self.model_name.startswith("ollama") or self.model_name.startswith(
-                "ollama_chat"
-            ):
-                error_msg += (
-                    "Ollama models don't support tool_choice='required', so tool calls are optional. "
-                    "Ensure your system prompt explicitly requires tool calls and that the model "
-                    "supports function calling."
-                )
-            else:
-                error_msg += (
-                    "This may indicate the model doesn't support tool_choice='required'. "
-                    "Check the system prompt and ensure it explicitly requires tool calls."
-                )
-            raise ValueError(error_msg)
+        else:
+            tool_calls = await bot(
+                prep_res["memory"],
+                execution_history=prep_res.get("execution_history"),
+            )
 
-        tool_call = tool_calls[0]
+            if not tool_calls:
+                error_msg = (
+                    f"No tool calls returned from the model. Model: {self.model_name}. "
+                )
+                if self.model_name.startswith("ollama") or self.model_name.startswith(
+                    "ollama_chat"
+                ):
+                    error_msg += (
+                        "Ollama models don't support tool_choice='required', so tool calls are optional. "
+                        "Ensure your system prompt explicitly requires tool calls and that the model "
+                        "supports function calling."
+                    )
+                else:
+                    error_msg += (
+                        "This may indicate the model doesn't support tool_choice='required'. "
+                        "Check the system prompt and ensure it explicitly requires tool calls."
+                    )
+                raise ValueError(error_msg)
 
-        func_name = tool_call.function.name
-        func_args_json = tool_call.function.arguments
+            normalized_tool_calls = [
+                {
+                    "name": tool_call.function.name,
+                    "arguments": tool_call.function.arguments,
+                }
+                for tool_call in tool_calls
+            ]
+            next_tool_call = normalized_tool_calls.pop(0)
+            prep_res["pending_tool_calls"] = normalized_tool_calls
+            func_name = next_tool_call["name"]
+            func_args_json = next_tool_call["arguments"]
 
         if span_obj:
             span_obj["chosen_tool"] = func_name

--- a/llamabot/mcp/__init__.py
+++ b/llamabot/mcp/__init__.py
@@ -1,0 +1,11 @@
+"""MCP client integration for LlamaBot agents."""
+
+from llamabot.mcp.manager import MCPClientManager
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec, MCPStartupMode
+
+__all__ = [
+    "MCPClientManager",
+    "MCPIntegrationOptions",
+    "MCPServerSpec",
+    "MCPStartupMode",
+]

--- a/llamabot/mcp/__init__.py
+++ b/llamabot/mcp/__init__.py
@@ -1,11 +1,11 @@
 """MCP client integration for LlamaBot agents."""
 
 from llamabot.mcp.manager import MCPClientManager
-from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec, MCPStartupMode
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerConfig, MCPStartupMode
 
 __all__ = [
     "MCPClientManager",
     "MCPIntegrationOptions",
-    "MCPServerSpec",
+    "MCPServerConfig",
     "MCPStartupMode",
 ]

--- a/llamabot/mcp/adapter.py
+++ b/llamabot/mcp/adapter.py
@@ -1,0 +1,355 @@
+"""Adapt MCP tool definitions into LlamaBot ``@tool``-compatible callables."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable, Dict, List
+
+from loguru import logger
+
+from llamabot.components.pocketflow import nodeify as nodeify_decorator
+from llamabot.recorder import span as span_decorator
+
+from llamabot.mcp.session import PersistentMCPClientSession
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPStartupMode
+
+
+def sanitize_python_identifier(name: str) -> str:
+    """Turn an MCP tool name into a valid Python identifier fragment.
+
+    :param name: Raw tool or parameter name from the MCP server.
+    :return: Safe identifier fragment.
+    """
+    import re
+
+    s = re.sub(r"[^0-9a-zA-Z_]", "_", name)
+    if s and s[0].isdigit():
+        s = f"_{s}"
+    return s or "tool"
+
+
+def prefixed_tool_name(server_name: str, tool_name: str, sep: str) -> str:
+    """Build a namespaced tool name used for allow/deny lists.
+
+    :param server_name: Logical MCP server name.
+    :param tool_name: Remote tool name.
+    :param sep: Namespace separator.
+    :return: Prefixed name ``server{sep}tool``.
+    """
+    a = sanitize_python_identifier(server_name)
+    b = sanitize_python_identifier(tool_name)
+    return f"{a}{sep}{b}"
+
+
+def normalize_openai_parameters(input_schema: dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize MCP JSON Schema input into OpenAI function ``parameters`` shape.
+
+    :param input_schema: MCP tool ``inputSchema`` (may be ``None``).
+    :return: Dict with ``type``, ``properties``, and ``required`` (wire keys).
+    """
+    if not input_schema:
+        return {"type": "object", "properties": {}, "required": []}
+
+    if input_schema.get("type") == "object":
+        return {
+            "type": "object",
+            "properties": dict(input_schema.get("properties") or {}),
+            "required": list(input_schema.get("required") or []),
+        }
+
+    return {"type": "object", "properties": {}, "required": []}
+
+
+def remap_schema_properties_for_python(
+    properties: Dict[str, Any],
+    required_wire: List[str],
+) -> tuple[Dict[str, Any], Dict[str, str], List[str]]:
+    """Map JSON Schema property keys to valid Python parameter names.
+
+    :param properties: Original ``properties`` object from MCP.
+    :param required_wire: Required field names using wire keys.
+    :return: Tuple of new properties dict, wire-key map ``py_name -> wire_name``, and
+        required list using Python names.
+    """
+    new_props: Dict[str, Any] = {}
+    wire_map: Dict[str, str] = {}
+    used_py: set[str] = set()
+
+    for wire_name, schema_fragment in properties.items():
+        base = sanitize_python_identifier(wire_name)
+        py_name = base
+        n = 2
+        while py_name in used_py:
+            py_name = f"{base}_{n}"
+            n += 1
+        used_py.add(py_name)
+        wire_map[py_name] = wire_name
+        new_props[py_name] = schema_fragment
+
+    required_set_wire = set(required_wire)
+    new_required: List[str] = []
+    for py_name, wname in wire_map.items():
+        if wname in required_set_wire:
+            new_required.append(py_name)
+
+    return new_props, wire_map, new_required
+
+
+def format_call_tool_result(result: Any) -> Any:
+    """Serialize a FastMCP tool call result for the model.
+
+    :param result: Parsed tool call result from FastMCP.
+    :return: JSON-friendly Python value (typically ``dict`` or ``str``).
+    """
+    if result is None:
+        return None
+
+    if getattr(result, "is_error", False):
+        payload: Dict[str, Any] = {"error": True}
+        if getattr(result, "data", None) is not None:
+            payload["data"] = result.data
+        if getattr(result, "structured_content", None):
+            payload["structured_content"] = result.structured_content
+        blocks = getattr(result, "content", None) or []
+        texts: List[str] = []
+        for block in blocks:
+            text = getattr(block, "text", None)
+            if text is not None:
+                texts.append(text)
+        if texts:
+            payload["text"] = "\n".join(texts)
+        return payload
+
+    data = getattr(result, "data", None)
+    if data is not None:
+        return data
+    structured = getattr(result, "structured_content", None)
+    if structured is not None:
+        return structured
+
+    blocks = getattr(result, "content", None) or []
+    texts = []
+    for block in blocks:
+        text = getattr(block, "text", None)
+        if text is not None:
+            texts.append(text)
+    if texts:
+        return "\n".join(texts)
+    try:
+        return result.model_dump()
+    except Exception:
+        return str(result)
+
+
+def build_function_dict_for_mcp_tool(
+    python_name: str,
+    description: str,
+    parameters: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the nested ``function`` object attached to ``json_schema``.
+
+    :param python_name: Exposed Python function name for routing.
+    :param description: Combined human-readable description.
+    :param parameters: OpenAI-style parameters dict (Python param keys).
+    :return: Function dictionary for tools JSON schema.
+    """
+    props = parameters.get("properties") or {}
+    required = list(parameters.get("required") or [])
+    return {
+        "name": python_name,
+        "description": description,
+        "parameters": {
+            "type": "object",
+            "properties": props,
+            "required": required,
+        },
+    }
+
+
+def apply_llamabot_tool_wrappers(
+    fn: Callable[..., Any],
+    function_dict: dict[str, Any],
+    *,
+    loopback_name: str | None = "decide",
+    exclude_args: List[str] | None = None,
+) -> Callable[..., Any]:
+    """Attach ``json_schema``, spans, and PocketFlow node wiring like ``@tool``.
+
+    :param fn: Inner Python callable implementing the MCP proxy.
+    :param function_dict: OpenAI function metadata dict.
+    :param loopback_name: Routing loopback target (default ``decide``).
+    :param exclude_args: Span exclusions for sensitive argument names.
+    :return: Fully decorated tool callable.
+    """
+    wrapped = fn
+    wrapped.json_schema = {
+        "type": "function",
+        "function": function_dict,
+    }
+    wrapped = span_decorator(
+        operation_name=function_dict.get("name"),
+        exclude_args=exclude_args or [],
+    )(wrapped)
+    wrapped = nodeify_decorator(loopback_name=loopback_name)(wrapped)
+    return wrapped
+
+
+def make_mcp_proxy_callable(
+    session: PersistentMCPClientSession,
+    *,
+    python_name: str,
+    remote_tool_name: str,
+    description: str,
+    parameters_wire: dict[str, Any],
+    call_timeout: float | None,
+) -> Callable[..., Any]:
+    """Create a sync callable that forwards to ``session.client.call_tool``.
+
+    :param session: Active MCP session holder.
+    :param python_name: Sanitized Python symbol for routing.
+    :param remote_tool_name: Original MCP tool name on the server.
+    :param description: Docstring / schema description text.
+    :param parameters_wire: Normalized parameters using **wire** JSON keys.
+    :param call_timeout: Optional per-call timeout in seconds.
+    :return: Callable with ``__signature__`` for kwargs routing (Python param names).
+    """
+    props_wire = parameters_wire.get("properties") or {}
+    required_wire = list(parameters_wire.get("required") or [])
+
+    props_py, wire_map, required_py = remap_schema_properties_for_python(
+        props_wire,
+        required_wire,
+    )
+
+    parameters_py = {
+        "type": "object",
+        "properties": props_py,
+        "required": required_py,
+    }
+
+    params: list[inspect.Parameter] = []
+    for pname_py, pschema in props_py.items():
+        default: Any = inspect.Parameter.empty
+        if pname_py not in set(required_py):
+            if isinstance(pschema, dict) and "default" in pschema:
+                default = pschema["default"]
+            else:
+                default = None
+        params.append(
+            inspect.Parameter(
+                pname_py,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=Any,
+            )
+        )
+
+    sig = inspect.Signature(params)
+
+    def impl(**kwargs: Any) -> Any:
+        """Call the MCP ``call_tool`` endpoint using wire-schema argument keys."""
+        bound = sig.bind_partial(**kwargs)
+        bound.apply_defaults()
+        arguments: Dict[str, Any] = {}
+        for py_key, value in bound.arguments.items():
+            wire_key = wire_map.get(py_key, py_key)
+            arguments[wire_key] = value
+
+        async def _call() -> Any:
+            """Await FastMCP ``call_tool`` on the persistent session client."""
+            return await session.client.call_tool(remote_tool_name, arguments)
+
+        raw = session.run_coroutine(_call(), timeout=call_timeout)
+        return format_call_tool_result(raw)
+
+    impl.__name__ = python_name
+    impl.__doc__ = description or f"MCP tool `{remote_tool_name}`."
+    impl.__signature__ = sig  # type: ignore[attr-defined]
+    impl.__annotations__ = {p.name: Any for p in params}
+
+    function_dict = build_function_dict_for_mcp_tool(
+        python_name, description or "", parameters_py
+    )
+    return apply_llamabot_tool_wrappers(impl, function_dict)
+
+
+def mcp_tools_as_llamabot_tools(
+    session: PersistentMCPClientSession,
+    server_name: str,
+    remote_tools: List[Any],
+    *,
+    namespace_sep: str,
+    options: MCPIntegrationOptions,
+    call_timeout: float | None,
+) -> List[Callable[..., Any]]:
+    """Convert MCP ``Tool`` metadata objects into LlamaBot tools.
+
+    :param session: Connected MCP session for invocation.
+    :param server_name: Logical server name for namespacing.
+    :param remote_tools: Output of ``await client.list_tools()``.
+    :param namespace_sep: Separator between server and tool names.
+    :param options: Filtering options (allow/deny lists).
+    :param call_timeout: Optional per-call timeout.
+    :return: Decorated tool callables ready for :class:`~llamabot.bot.agentbot.AgentBot`.
+    """
+    out: List[Callable[..., Any]] = []
+    allow = options.allow_tools
+    deny = options.deny_tools or []
+
+    for rt in remote_tools:
+        remote_name: str = ""
+        desc = ""
+        input_schema: dict[str, Any] | None = None
+
+        if isinstance(rt, dict):
+            remote_name = str(rt.get("name", ""))
+            desc = str(rt.get("description", "") or "")
+            input_schema = rt.get("inputSchema") or rt.get("input_schema")
+            if input_schema is not None and not isinstance(input_schema, dict):
+                input_schema = None
+        else:
+            remote_name = str(getattr(rt, "name", "") or "")
+            desc = str(getattr(rt, "description", "") or "")
+            raw_schema = getattr(rt, "inputSchema", None)
+            if raw_schema is None:
+                input_schema = None
+            elif isinstance(raw_schema, dict):
+                input_schema = raw_schema
+            elif hasattr(raw_schema, "model_dump"):
+                dumped = raw_schema.model_dump()
+                input_schema = dumped if isinstance(dumped, dict) else None
+            else:
+                input_schema = None
+
+        prefixed = prefixed_tool_name(server_name, remote_name, namespace_sep)
+        if allow is not None and prefixed not in allow:
+            continue
+        if prefixed in deny:
+            continue
+
+        py_name = prefixed
+        normalized_wire = normalize_openai_parameters(input_schema)
+
+        header = f"[MCP:{server_name}] {remote_name}"
+        description = f"{header}\n\n{desc}".strip()
+
+        try:
+            fn = make_mcp_proxy_callable(
+                session,
+                python_name=py_name,
+                remote_tool_name=remote_name,
+                description=description,
+                parameters_wire=normalized_wire,
+                call_timeout=call_timeout,
+            )
+            out.append(fn)
+        except Exception:
+            logger.exception(
+                "Skipping MCP tool {!r} from server {!r}",
+                remote_name,
+                server_name,
+            )
+            if options.startup_mode == MCPStartupMode.STRICT:
+                raise
+
+    return out

--- a/llamabot/mcp/manager.py
+++ b/llamabot/mcp/manager.py
@@ -11,7 +11,7 @@ from llamabot.mcp.session import PersistentMCPClientSession, build_fastmcp_clien
 from llamabot.mcp.specs import (
     MCPIntegrationOptions,
     MCPStartupMode,
-    coerce_mcp_server_specs,
+    coerce_mcp_server_configs,
 )
 
 
@@ -27,7 +27,7 @@ class MCPClientManager:
         servers: List[Any],
         options: MCPIntegrationOptions | None = None,
     ) -> None:
-        self._servers = coerce_mcp_server_specs(list(servers))
+        self._servers = coerce_mcp_server_configs(list(servers))
         self._options = options or MCPIntegrationOptions()
         self._sessions: dict[str, PersistentMCPClientSession] = {}
         self._failures: list[tuple[str, BaseException]] = []
@@ -47,19 +47,19 @@ class MCPClientManager:
         :raises RuntimeError: In strict mode when startup fails.
         """
         self._failures.clear()
-        for spec in self._servers:
-            client = build_fastmcp_client(spec, self._options)
+        for config in self._servers:
+            client = build_fastmcp_client(config, self._options)
             session = PersistentMCPClientSession(
                 client,
                 connect_timeout=float(self._options.connect_timeout_seconds),
             )
             try:
                 session.start()
-                self._sessions[spec.name] = session
-                logger.info("Connected MCP server {!r}", spec.name)
+                self._sessions[config.name] = session
+                logger.info("Connected MCP server {!r}", config.name)
             except BaseException as exc:
-                self._failures.append((spec.name, exc))
-                logger.exception("Failed to connect MCP server {!r}", spec.name)
+                self._failures.append((config.name, exc))
+                logger.exception("Failed to connect MCP server {!r}", config.name)
                 if self._options.startup_mode == MCPStartupMode.STRICT:
                     self.close()
                     raise
@@ -80,8 +80,8 @@ class MCPClientManager:
         tools: List[Callable[..., Any]] = []
         sep = self._options.tool_namespace_sep
         call_timeout = self._options.call_timeout_seconds
-        for spec in self._servers:
-            session = self._sessions.get(spec.name)
+        for config in self._servers:
+            session = self._sessions.get(config.name)
             if session is None:
                 continue
 
@@ -92,7 +92,7 @@ class MCPClientManager:
             tools.extend(
                 mcp_tools_as_llamabot_tools(
                     session,
-                    spec.name,
+                    config.name,
                     remote_tools,
                     namespace_sep=sep,
                     options=self._options,

--- a/llamabot/mcp/manager.py
+++ b/llamabot/mcp/manager.py
@@ -8,7 +8,11 @@ from loguru import logger
 
 from llamabot.mcp.adapter import mcp_tools_as_llamabot_tools
 from llamabot.mcp.session import PersistentMCPClientSession, build_fastmcp_client
-from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec, MCPStartupMode
+from llamabot.mcp.specs import (
+    MCPIntegrationOptions,
+    MCPStartupMode,
+    coerce_mcp_server_specs,
+)
 
 
 class MCPClientManager:
@@ -20,10 +24,10 @@ class MCPClientManager:
 
     def __init__(
         self,
-        servers: List[MCPServerSpec],
+        servers: List[Any],
         options: MCPIntegrationOptions | None = None,
     ) -> None:
-        self._servers = list(servers)
+        self._servers = coerce_mcp_server_specs(list(servers))
         self._options = options or MCPIntegrationOptions()
         self._sessions: dict[str, PersistentMCPClientSession] = {}
         self._failures: list[tuple[str, BaseException]] = []

--- a/llamabot/mcp/manager.py
+++ b/llamabot/mcp/manager.py
@@ -1,0 +1,98 @@
+"""MCP client lifecycle: connect servers and expose LlamaBot tools."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List
+
+from loguru import logger
+
+from llamabot.mcp.adapter import mcp_tools_as_llamabot_tools
+from llamabot.mcp.session import PersistentMCPClientSession, build_fastmcp_client
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec, MCPStartupMode
+
+
+class MCPClientManager:
+    """Connect to declared MCP servers and expose LlamaBot-compatible tools.
+
+    :param servers: MCP servers to connect at :meth:`start`.
+    :param options: Optional integration settings.
+    """
+
+    def __init__(
+        self,
+        servers: List[MCPServerSpec],
+        options: MCPIntegrationOptions | None = None,
+    ) -> None:
+        self._servers = list(servers)
+        self._options = options or MCPIntegrationOptions()
+        self._sessions: dict[str, PersistentMCPClientSession] = {}
+        self._failures: list[tuple[str, BaseException]] = []
+
+    @property
+    def failures(self) -> list[tuple[str, BaseException]]:
+        """Servers that failed under ``best_effort`` startup.
+
+        :return: List of ``(server_name, error)`` pairs.
+        """
+        return list(self._failures)
+
+    def start(self) -> None:
+        """Connect all configured servers.
+
+        :raises TimeoutError: In strict mode when a server hits connect timeout.
+        :raises RuntimeError: In strict mode when startup fails.
+        """
+        self._failures.clear()
+        for spec in self._servers:
+            client = build_fastmcp_client(spec, self._options)
+            session = PersistentMCPClientSession(
+                client,
+                connect_timeout=float(self._options.connect_timeout_seconds),
+            )
+            try:
+                session.start()
+                self._sessions[spec.name] = session
+                logger.info("Connected MCP server {!r}", spec.name)
+            except BaseException as exc:
+                self._failures.append((spec.name, exc))
+                logger.exception("Failed to connect MCP server {!r}", spec.name)
+                if self._options.startup_mode == MCPStartupMode.STRICT:
+                    self.close()
+                    raise
+
+    def close(self) -> None:
+        """Close all MCP sessions."""
+        for sess in self._sessions.values():
+            sess.close()
+        self._sessions.clear()
+
+    def llamabot_tools(self) -> List[Callable[..., Any]]:
+        """Build ``@tool``-compatible callables for all discovered MCP tools.
+
+        Call after :meth:`start`.
+
+        :return: List of decorated tool functions.
+        """
+        tools: List[Callable[..., Any]] = []
+        sep = self._options.tool_namespace_sep
+        call_timeout = self._options.call_timeout_seconds
+        for spec in self._servers:
+            session = self._sessions.get(spec.name)
+            if session is None:
+                continue
+
+            remote_tools = session.run_coroutine(
+                session.client.list_tools(),
+                timeout=call_timeout,
+            )
+            tools.extend(
+                mcp_tools_as_llamabot_tools(
+                    session,
+                    spec.name,
+                    remote_tools,
+                    namespace_sep=sep,
+                    options=self._options,
+                    call_timeout=call_timeout,
+                )
+            )
+        return tools

--- a/llamabot/mcp/session.py
+++ b/llamabot/mcp/session.py
@@ -1,0 +1,190 @@
+"""Low-level MCP session: FastMCP client construction and persistent asyncio session."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from datetime import timedelta
+from typing import Any
+
+from loguru import logger
+
+from fastmcp import Client
+from fastmcp.mcp_config import RemoteMCPServer, StdioMCPServer
+
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec
+
+
+def build_fastmcp_client(spec: MCPServerSpec, options: MCPIntegrationOptions) -> Client:
+    """Create a :class:`fastmcp.Client` from a server spec.
+
+    :param spec: Declared MCP server.
+    :param options: Integration timeouts and client options.
+    :return: Configured FastMCP client (not yet connected).
+    """
+    kwargs: dict[str, Any] = {}
+    if options.client_timeout_seconds is not None:
+        kwargs["timeout"] = timedelta(seconds=float(options.client_timeout_seconds))
+    if options.client_init_timeout_seconds is not None:
+        kwargs["init_timeout"] = float(options.client_init_timeout_seconds)
+
+    if spec.transport == "inproc":
+        return Client(spec.fastmcp, name=spec.name, **kwargs)
+
+    if spec.transport == "stdio":
+        stdio = StdioMCPServer(
+            command=spec.command,
+            args=list(spec.args),
+            env=dict(spec.env),
+            cwd=spec.cwd,
+        )
+        return Client(stdio.to_transport(), name=spec.name, **kwargs)
+
+    remote_transport: str | None
+    if spec.remote_transport is not None:
+        remote_transport = spec.remote_transport
+    elif spec.transport == "http":
+        remote_transport = None
+    elif spec.transport == "sse":
+        remote_transport = "sse"
+    elif spec.transport == "streamable-http":
+        remote_transport = "streamable-http"
+    else:
+        remote_transport = None
+
+    sse_read_timeout = None
+    if spec.sse_read_timeout_seconds is not None:
+        sse_read_timeout = timedelta(seconds=float(spec.sse_read_timeout_seconds))
+
+    remote = RemoteMCPServer(
+        url=spec.url,
+        transport=remote_transport,
+        headers=dict(spec.headers),
+        auth=spec.auth,
+        sse_read_timeout=sse_read_timeout,
+    )
+    return Client(remote.to_transport(), name=spec.name, **kwargs)
+
+
+class PersistentMCPClientSession:
+    """Hold one connected :class:`fastmcp.Client` on a dedicated event-loop thread.
+
+    :param client: FastMCP client to connect.
+    :param connect_timeout: Seconds to wait for the session to become ready.
+    """
+
+    def __init__(self, client: Client, connect_timeout: float) -> None:
+        self._client = client
+        self._connect_timeout = connect_timeout
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._ready = threading.Event()
+        self._stop_fut: asyncio.Future[Any] | None = None
+        self._startup_error: BaseException | None = None
+
+    @property
+    def client(self) -> Client:
+        """Return the wrapped FastMCP client.
+
+        :return: Client instance.
+        """
+        return self._client
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop | None:
+        """Return the background event loop, if started.
+
+        :return: Event loop or ``None``.
+        """
+        return self._loop
+
+    def start(self) -> None:
+        """Start the background thread and wait until the MCP session is ready.
+
+        :raises TimeoutError: When connect timeout elapses before readiness.
+        :raises RuntimeError: When the session fails to start.
+        """
+
+        def runner() -> None:
+            """Run the MCP client session on a dedicated asyncio event loop."""
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self._loop = loop
+
+            async def hold_session() -> None:
+                """Enter ``async with client``, signal readiness, await shutdown."""
+                try:
+                    async with self._client:
+                        self._ready.set()
+                        stop_wait: asyncio.Future[Any] = loop.create_future()
+                        self._stop_fut = stop_wait
+                        await stop_wait
+                except BaseException as exc:
+                    self._startup_error = exc
+                    self._ready.set()
+                    raise
+
+            try:
+                loop.run_until_complete(hold_session())
+            except BaseException:
+                # Failure is surfaced via ``_startup_error`` after ``_ready``;
+                # swallow here so the worker thread exits without threading leaks.
+                pass
+            finally:
+                try:
+                    pending = asyncio.all_tasks(loop)
+                    for t in pending:
+                        t.cancel()
+                    if pending:
+                        loop.run_until_complete(
+                            asyncio.gather(*pending, return_exceptions=True)
+                        )
+                except Exception:
+                    logger.exception("Error cancelling MCP background tasks")
+                loop.close()
+
+        self._thread = threading.Thread(
+            target=runner,
+            daemon=True,
+            name=f"mcp-session-{self._client.name}",
+        )
+        self._thread.start()
+        if not self._ready.wait(timeout=self._connect_timeout):
+            self.close()
+            raise TimeoutError(
+                f"MCP server {self._client.name!r} did not become ready within "
+                f"{self._connect_timeout} seconds"
+            )
+        if self._startup_error is not None:
+            err = self._startup_error
+            self.close()
+            raise RuntimeError(
+                f"MCP server {self._client.name!r} failed to start"
+            ) from err
+
+    def run_coroutine(self, coro: Any, *, timeout: float | None) -> Any:
+        """Run an awaitable on the session loop from another thread.
+
+        :param coro: Coroutine produced by the FastMCP client.
+        :param timeout: Optional timeout in seconds for the operation.
+        :return: Coroutine result.
+        """
+        if self._loop is None:
+            raise RuntimeError("MCP session loop is not running")
+        fut = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return fut.result(timeout=timeout)
+
+    def close(self) -> None:
+        """Signal shutdown and join the background thread."""
+        if self._loop is not None and self._stop_fut is not None:
+            if not self._stop_fut.done():
+
+                def resolve() -> None:
+                    """Complete the stop future so the session context can exit."""
+                    if self._stop_fut is not None and not self._stop_fut.done():
+                        self._stop_fut.set_result(None)
+
+                self._loop.call_soon_threadsafe(resolve)
+        if self._thread is not None:
+            self._thread.join(timeout=15.0)
+            self._thread = None

--- a/llamabot/mcp/session.py
+++ b/llamabot/mcp/session.py
@@ -12,13 +12,15 @@ from loguru import logger
 from fastmcp import Client
 from fastmcp.mcp_config import RemoteMCPServer, StdioMCPServer
 
-from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerConfig
 
 
-def build_fastmcp_client(spec: MCPServerSpec, options: MCPIntegrationOptions) -> Client:
-    """Create a :class:`fastmcp.Client` from a server spec.
+def build_fastmcp_client(
+    config: MCPServerConfig, options: MCPIntegrationOptions
+) -> Client:
+    """Create a :class:`fastmcp.Client` from a server config.
 
-    :param spec: Declared MCP server.
+    :param config: Declared MCP server configuration.
     :param options: Integration timeouts and client options.
     :return: Configured FastMCP client (not yet connected).
     """
@@ -28,42 +30,42 @@ def build_fastmcp_client(spec: MCPServerSpec, options: MCPIntegrationOptions) ->
     if options.client_init_timeout_seconds is not None:
         kwargs["init_timeout"] = float(options.client_init_timeout_seconds)
 
-    if spec.transport == "inproc":
-        return Client(spec.fastmcp, name=spec.name, **kwargs)
+    if config.transport == "inproc":
+        return Client(config.fastmcp, name=config.name, **kwargs)
 
-    if spec.transport == "stdio":
+    if config.transport == "stdio":
         stdio = StdioMCPServer(
-            command=spec.command,
-            args=list(spec.args),
-            env=dict(spec.env),
-            cwd=spec.cwd,
+            command=config.command,
+            args=list(config.args),
+            env=dict(config.env),
+            cwd=config.cwd,
         )
-        return Client(stdio.to_transport(), name=spec.name, **kwargs)
+        return Client(stdio.to_transport(), name=config.name, **kwargs)
 
     remote_transport: str | None
-    if spec.remote_transport is not None:
-        remote_transport = spec.remote_transport
-    elif spec.transport == "http":
+    if config.remote_transport is not None:
+        remote_transport = config.remote_transport
+    elif config.transport == "http":
         remote_transport = None
-    elif spec.transport == "sse":
+    elif config.transport == "sse":
         remote_transport = "sse"
-    elif spec.transport == "streamable-http":
+    elif config.transport == "streamable-http":
         remote_transport = "streamable-http"
     else:
         remote_transport = None
 
     sse_read_timeout = None
-    if spec.sse_read_timeout_seconds is not None:
-        sse_read_timeout = timedelta(seconds=float(spec.sse_read_timeout_seconds))
+    if config.sse_read_timeout_seconds is not None:
+        sse_read_timeout = timedelta(seconds=float(config.sse_read_timeout_seconds))
 
     remote = RemoteMCPServer(
-        url=spec.url,
+        url=config.url,
         transport=remote_transport,
-        headers=dict(spec.headers),
-        auth=spec.auth,
+        headers=dict(config.headers),
+        auth=config.auth,
         sse_read_timeout=sse_read_timeout,
     )
-    return Client(remote.to_transport(), name=spec.name, **kwargs)
+    return Client(remote.to_transport(), name=config.name, **kwargs)
 
 
 class PersistentMCPClientSession:

--- a/llamabot/mcp/specs.py
+++ b/llamabot/mcp/specs.py
@@ -105,3 +105,49 @@ class MCPServerSpec(BaseModel):
             if not self.url:
                 raise ValueError(f"{self.transport} transport requires 'url'")
         return self
+
+
+def coerce_mcp_server_specs(servers: list[Any]) -> list[MCPServerSpec]:
+    """Normalize user-facing ``mcp_servers`` inputs into ``MCPServerSpec`` objects.
+
+    Supports:
+
+    - ``MCPServerSpec`` instances (returned as-is)
+    - ``dict`` objects accepted by ``MCPServerSpec(**dict)``
+    - ``fastmcp.FastMCP`` instances (auto-wrapped as ``transport='inproc'``)
+
+    :param servers: Mixed server configuration inputs.
+    :return: Normalized list of ``MCPServerSpec`` values.
+    :raises TypeError: If an input entry cannot be interpreted as an MCP server.
+    """
+    fastmcp_cls: Any = None
+    try:
+        from fastmcp import FastMCP
+
+        fastmcp_cls = FastMCP
+    except Exception:
+        fastmcp_cls = None
+
+    normalized: list[MCPServerSpec] = []
+    for index, server in enumerate(servers):
+        if isinstance(server, MCPServerSpec):
+            normalized.append(server)
+            continue
+
+        if isinstance(server, dict):
+            normalized.append(MCPServerSpec(**server))
+            continue
+
+        if fastmcp_cls is not None and isinstance(server, fastmcp_cls):
+            server_name = str(getattr(server, "name", "")).strip() or f"mcp_{index}"
+            normalized.append(
+                MCPServerSpec(name=server_name, transport="inproc", fastmcp=server)
+            )
+            continue
+
+        raise TypeError(
+            "Unsupported mcp_servers entry. Expected MCPServerSpec, dict, or "
+            f"FastMCP instance, got: {type(server).__name__}"
+        )
+
+    return normalized

--- a/llamabot/mcp/specs.py
+++ b/llamabot/mcp/specs.py
@@ -1,0 +1,107 @@
+"""Transport-agnostic MCP server configuration for LlamaBot."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class MCPStartupMode(str, Enum):
+    """How to behave when an MCP server fails during startup."""
+
+    STRICT = "strict"
+    BEST_EFFORT = "best_effort"
+
+
+class MCPIntegrationOptions(BaseModel):
+    """Options for merging MCP tools with Python tools."""
+
+    startup_mode: MCPStartupMode = MCPStartupMode.BEST_EFFORT
+    """If ``strict``, raise when any configured server fails to connect or list tools."""
+
+    tool_namespace_sep: str = "__"
+    """Separator between server name and remote tool name in generated Python identifiers."""
+
+    connect_timeout_seconds: float = 60.0
+    """Time to wait for the MCP session to become ready."""
+
+    call_timeout_seconds: Optional[float] = None
+    """Per-tool-call timeout in seconds; ``None`` uses the FastMCP client default."""
+
+    allow_tools: Optional[list[str]] = None
+    """If set, only register tools whose prefixed names are in this list."""
+
+    deny_tools: Optional[list[str]] = None
+    """If set, skip tools whose prefixed names appear here."""
+
+    client_timeout_seconds: Optional[float] = None
+    """Optional timeout passed to :class:`fastmcp.Client` (seconds)."""
+
+    client_init_timeout_seconds: Optional[float] = None
+    """Optional MCP initialize handshake timeout for :class:`fastmcp.Client` (seconds)."""
+
+
+class MCPServerSpec(BaseModel):
+    """Declares one MCP server for use with :class:`~llamabot.mcp.manager.MCPClientManager`.
+
+    Supports stdio subprocess servers, remote HTTP / Streamable HTTP / SSE URLs, and
+    in-process :class:`fastmcp.FastMCP` instances (primarily for tests).
+    """
+
+    name: str
+    """Logical server name used for namespacing and logging."""
+
+    transport: Literal["stdio", "http", "sse", "streamable-http", "inproc"] = "stdio"
+    """Transport kind; ``inproc`` embeds a :class:`fastmcp.FastMCP` server in-process."""
+
+    command: Optional[str] = None
+    """Executable for ``stdio`` transport."""
+
+    args: list[str] = Field(default_factory=list)
+    """Arguments for ``stdio`` transport."""
+
+    env: dict[str, Any] = Field(default_factory=dict)
+    """Extra environment variables for ``stdio`` transport."""
+
+    cwd: Optional[str] = None
+    """Working directory for ``stdio`` transport."""
+
+    url: Optional[str] = None
+    """Endpoint URL for remote transports."""
+
+    remote_transport: Optional[Literal["http", "sse", "streamable-http"]] = None
+    """Explicit remote transport; if omitted, FastMCP infers from ``url``."""
+
+    headers: dict[str, str] = Field(default_factory=dict)
+    """HTTP headers for remote transports."""
+
+    auth: Any = None
+    """Optional auth for remote transports (Bearer string, ``\"oauth\"``, or ``httpx.Auth``)."""
+
+    sse_read_timeout_seconds: Optional[float] = None
+    """Optional SSE read timeout for remote transports (seconds)."""
+
+    fastmcp: Any = Field(default=None, repr=False)
+    """In-process :class:`fastmcp.FastMCP` instance when ``transport == \"inproc\"``."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    @model_validator(mode="after")
+    def validate_transport_fields(self) -> MCPServerSpec:
+        """Ensure required fields exist for each transport.
+
+        :return: Validated spec.
+        :raises ValueError: When configuration is inconsistent.
+        """
+        if self.transport == "stdio":
+            if not self.command:
+                raise ValueError("stdio transport requires 'command'")
+        elif self.transport == "inproc":
+            if self.fastmcp is None:
+                raise ValueError("inproc transport requires 'fastmcp' instance")
+        else:
+            if not self.url:
+                raise ValueError(f"{self.transport} transport requires 'url'")
+        return self

--- a/llamabot/mcp/specs.py
+++ b/llamabot/mcp/specs.py
@@ -43,7 +43,7 @@ class MCPIntegrationOptions(BaseModel):
     """Optional MCP initialize handshake timeout for :class:`fastmcp.Client` (seconds)."""
 
 
-class MCPServerSpec(BaseModel):
+class MCPServerConfig(BaseModel):
     """Declares one MCP server for use with :class:`~llamabot.mcp.manager.MCPClientManager`.
 
     Supports stdio subprocess servers, remote HTTP / Streamable HTTP / SSE URLs, and
@@ -89,10 +89,10 @@ class MCPServerSpec(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
 
     @model_validator(mode="after")
-    def validate_transport_fields(self) -> MCPServerSpec:
+    def validate_transport_fields(self) -> MCPServerConfig:
         """Ensure required fields exist for each transport.
 
-        :return: Validated spec.
+        :return: Validated config.
         :raises ValueError: When configuration is inconsistent.
         """
         if self.transport == "stdio":
@@ -107,17 +107,17 @@ class MCPServerSpec(BaseModel):
         return self
 
 
-def coerce_mcp_server_specs(servers: list[Any]) -> list[MCPServerSpec]:
-    """Normalize user-facing ``mcp_servers`` inputs into ``MCPServerSpec`` objects.
+def coerce_mcp_server_configs(servers: list[Any]) -> list[MCPServerConfig]:
+    """Normalize user-facing ``mcp_servers`` inputs into ``MCPServerConfig`` objects.
 
     Supports:
 
-    - ``MCPServerSpec`` instances (returned as-is)
-    - ``dict`` objects accepted by ``MCPServerSpec(**dict)``
+    - ``MCPServerConfig`` instances (returned as-is)
+    - ``dict`` objects accepted by ``MCPServerConfig(**dict)``
     - ``fastmcp.FastMCP`` instances (auto-wrapped as ``transport='inproc'``)
 
     :param servers: Mixed server configuration inputs.
-    :return: Normalized list of ``MCPServerSpec`` values.
+    :return: Normalized list of ``MCPServerConfig`` values.
     :raises TypeError: If an input entry cannot be interpreted as an MCP server.
     """
     fastmcp_cls: Any = None
@@ -128,25 +128,25 @@ def coerce_mcp_server_specs(servers: list[Any]) -> list[MCPServerSpec]:
     except Exception:
         fastmcp_cls = None
 
-    normalized: list[MCPServerSpec] = []
+    normalized: list[MCPServerConfig] = []
     for index, server in enumerate(servers):
-        if isinstance(server, MCPServerSpec):
+        if isinstance(server, MCPServerConfig):
             normalized.append(server)
             continue
 
         if isinstance(server, dict):
-            normalized.append(MCPServerSpec(**server))
+            normalized.append(MCPServerConfig(**server))
             continue
 
         if fastmcp_cls is not None and isinstance(server, fastmcp_cls):
             server_name = str(getattr(server, "name", "")).strip() or f"mcp_{index}"
             normalized.append(
-                MCPServerSpec(name=server_name, transport="inproc", fastmcp=server)
+                MCPServerConfig(name=server_name, transport="inproc", fastmcp=server)
             )
             continue
 
         raise TypeError(
-            "Unsupported mcp_servers entry. Expected MCPServerSpec, dict, or "
+            "Unsupported mcp_servers entry. Expected MCPServerConfig, dict, or "
             f"FastMCP instance, got: {type(server).__name__}"
         )
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -26,6 +26,7 @@ nav:
     - "Generate Blog Banner Images": how-to/generate-blog-banner-images.md
     - "Process Receipts with LLM Agents": how-to/receipt-processing.md
     - "Build a Data Analysis Chatbot": how-to/data-analysis-agentbot.md
+    - "AgentBot with MCP tools": how-to/agent-mcp-tools.md
   - Tutorials:
     - "SimpleBot Tutorial": tutorials/simplebot.md
     - "StructuredBot Tutorial": tutorials/structuredbot.md

--- a/notebooks/mcp-tools.py
+++ b/notebooks/mcp-tools.py
@@ -1,0 +1,303 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "marimo",
+#     "llamabot==0.18.1",
+#     "fastmcp==3.2.4",
+# ]
+#
+# [tool.uv.sources]
+# llamabot = { path = "../", editable = true }
+#
+# ///
+
+import marimo
+
+__generated_with = "0.23.4"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+
+    mo.md(
+        r"""
+    # MCP tools with LlamaBot AgentBot
+
+    This tutorial shows **first-class MCP integration** in LlamaBot. You will:
+
+    1. Define MCP tools on a FastMCP server.
+    2. Register those tools with LlamaBot via `mcp_servers=`.
+    3. Run an `AgentBot` that can use both Python tools and MCP tools.
+
+    **Important:** always call `bot.close_mcp()` when done so sessions shut down cleanly.
+    """
+    )
+
+    return
+
+
+@app.cell
+def _():
+
+    import os
+
+    from fastmcp import FastMCP
+
+    from llamabot.bot.agentbot import AgentBot
+    from llamabot.components.tools import tool
+    from llamabot.mcp.manager import MCPClientManager
+    from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec, MCPStartupMode
+
+    @tool
+    def local_uppercase(text: str) -> str:
+        """Uppercase text with a local Python tool.
+
+        :param text: Input text.
+        :return: Uppercased text.
+        """
+        return text.upper()
+
+    demo_mcp = FastMCP("llamabot_mcp_tutorial")
+
+    @demo_mcp.tool()
+    def greet(name: str) -> str:
+        """Return a short greeting.
+
+        :param name: Who to greet.
+        :return: Greeting string.
+        """
+        return f"Hello, {name}! (from MCP tool greet)"
+
+    @demo_mcp.tool()
+    def add_numbers(a: int, b: int) -> int:
+        """Add two integers.
+
+        :param a: First summand.
+        :param b: Second summand.
+        :return: Sum.
+        """
+        return a + b
+
+    return (
+        AgentBot,
+        MCPClientManager,
+        MCPIntegrationOptions,
+        MCPServerSpec,
+        MCPStartupMode,
+        demo_mcp,
+        local_uppercase,
+        os,
+    )
+
+
+@app.cell
+def _(
+    MCPClientManager,
+    MCPIntegrationOptions,
+    MCPServerSpec,
+    MCPStartupMode,
+    demo_mcp,
+    mo,
+):
+
+    spec_preview = MCPServerSpec(name="demo", transport="inproc", fastmcp=demo_mcp)
+    opts_preview = MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT)
+
+    mgr = MCPClientManager([spec_preview], opts_preview)
+    mgr.start()
+    try:
+        wrapped = mgr.llamabot_tools()
+        names = [
+            getattr(getattr(fn, "func", fn), "__name__", "<unknown>") for fn in wrapped
+        ]
+        bullets = "\n".join([f"- `{n}`" for n in names])
+    finally:
+        mgr.close()
+
+    mo.md(
+        "## Registered MCP tool names\n\n"
+        "These names are what ToolBot/DecideNode routes on.\n\n"
+        f"{bullets}"
+    )
+
+    return
+
+
+@app.cell
+def _(mo):
+
+    model_choice = mo.ui.dropdown(
+        options={
+            "Anthropic Sonnet 4.5": "anthropic/claude-sonnet-4-5-20250929",
+            "LM Studio (OpenAI-compatible local endpoint)": "openai/qwen/qwen3.6-35b-a3b",
+            "OpenAI (requires OPENAI_API_KEY)": "openai/gpt-4.1-mini",
+            "Ollama local": "ollama_chat/qwen2.5:0.5b",
+        },
+        value="Anthropic Sonnet 4.5",
+        label="Model",
+        full_width=True,
+    )
+
+    user_query = mo.ui.text_area(
+        value=(
+            "Use MCP tool demo__greet to greet Ada, then "
+            "use local_uppercase on the phrase hello mcp."
+        ),
+        label="User query",
+        full_width=True,
+    )
+
+    run_agent = mo.ui.run_button(label="Run AgentBot")
+
+    mo.vstack(
+        [
+            mo.md("## Run an AgentBot with MCP + Python tools"),
+            mo.md(
+                "Recommended default: **Anthropic Sonnet 4.5**. "
+                "LM Studio is also available for local testing."
+            ),
+            model_choice,
+            user_query,
+            run_agent,
+        ]
+    )
+
+    return model_choice, run_agent, user_query
+
+
+@app.cell
+def _(
+    AgentBot,
+    MCPIntegrationOptions,
+    MCPServerSpec,
+    MCPStartupMode,
+    demo_mcp,
+    local_uppercase,
+    mo,
+    model_choice,
+    os,
+    run_agent,
+    user_query,
+):
+    mo.stop(not run_agent.value, mo.md("Click **Run AgentBot** to execute one run."))
+
+    api_kwargs = {}
+    selected_model = model_choice.value
+
+    if selected_model == "anthropic/claude-sonnet-4-5-20250929":
+        if not os.environ.get("ANTHROPIC_API_KEY"):
+            mo.stop(True, mo.md(":warning: Set ANTHROPIC_API_KEY for Sonnet 4.5."))
+    elif selected_model == "openai/qwen/qwen3.6-35b-a3b":
+        lmstudio_api_base = os.environ.get(
+            "OPENAI_API_BASE", "http://localhost:1234/v1"
+        )
+        lmstudio_api_key = os.environ.get("OPENAI_API_KEY", "lm-studio")
+        api_kwargs = {
+            "api_base": lmstudio_api_base,
+            "api_key": lmstudio_api_key,
+        }
+        mo.output.append(mo.md(f"Using LM Studio endpoint: `{lmstudio_api_base}`"))
+    elif selected_model == "openai/gpt-4.1-mini":
+        if not os.environ.get("OPENAI_API_KEY"):
+            mo.stop(True, mo.md(":warning: Set OPENAI_API_KEY or switch models."))
+
+    spec_agent = MCPServerSpec(name="demo", transport="inproc", fastmcp=demo_mcp)
+    opts_agent = MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT)
+
+    bot = AgentBot(
+        tools=[local_uppercase],
+        system_prompt=(
+            "You are a careful assistant. Prefer tools when useful. "
+            "MCP tools are namespaced (for example demo__greet)."
+        ),
+        model_name=selected_model,
+        max_iterations=8,
+        mcp_servers=[spec_agent],
+        mcp_options=opts_agent,
+        **api_kwargs,
+    )
+
+    # LM Studio + qwen/qwen3.6-35b-a3b may not emit structured tool_calls when
+    # ToolBot enforces tool_choice='required'. For this model, prefer auto.
+    if selected_model == "openai/qwen/qwen3.6-35b-a3b":
+        if hasattr(bot, "decide_node") and hasattr(bot.decide_node, "toolbot"):
+            bot.decide_node.toolbot.tool_choice = "auto"
+
+    try:
+        result = bot(user_query.value)
+    finally:
+        bot.close_mcp()
+
+    mo.vstack(
+        [
+            mo.md("### Agent result"),
+            mo.md(f"```\n{result}\n```") if isinstance(result, str) else result,
+        ]
+    )
+
+    return
+
+
+@app.cell
+def _(mo):
+
+    mo.md(
+        r"""
+    ## Model and provider syntax cheatsheet
+
+    ### Anthropic Sonnet 4.5 (recommended)
+
+    - LiteLLM model id: `anthropic/claude-sonnet-4-5-20250929`
+    - Required env var: `ANTHROPIC_API_KEY`
+    - No custom `api_base` needed.
+
+    ### LM Studio (OpenAI-compatible local)
+
+    ```bash
+    export OPENAI_API_BASE=http://localhost:1234/v1
+    # Optional if your local gateway expects a key:
+    export OPENAI_API_KEY=lm-studio
+    ```
+
+    Model string in this notebook: `openai/qwen/qwen3.6-35b-a3b`
+
+    ### Stdio MCP server
+
+    ```python
+    docs_spec = MCPServerSpec(
+        name="docs",
+        transport="stdio",
+        command="uvx",
+        args=["--with", "llamabot[all]", "llamabot", "mcp", "launch"],
+    )
+    ```
+
+    ### Remote HTTP / SSE MCP server
+
+    ```python
+    remote_spec = MCPServerSpec(
+        name="remote",
+        transport="http",  # or "sse"
+        url="http://localhost:8765/mcp",
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+    ```
+
+    Use `MCPStartupMode.BEST_EFFORT` if some servers may be offline.
+    """
+    )
+
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/notebooks/mcp-tools.py
+++ b/notebooks/mcp-tools.py
@@ -110,15 +110,13 @@ def _(MCPClientManager, demo_mcp, mo):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
-
     model_choice = mo.ui.dropdown(
         options={
             "Anthropic Sonnet 4.5": "anthropic/claude-sonnet-4-5-20250929",
-            "LM Studio (OpenAI-compatible local endpoint)": "openai/qwen/qwen3.6-35b-a3b",
-            "OpenAI (requires OPENAI_API_KEY)": "openai/gpt-4.1-mini",
-            "Ollama local": "ollama_chat/qwen2.5:0.5b",
+            "Anthropic Opus 4.5": "anthropic/claude-opus-4-5-20251101",
+            "Anthropic Haiku 4.5 (latest)": "anthropic/claude-haiku-4-5-20251001",
         },
         value="Anthropic Sonnet 4.5",
         label="Model",
@@ -139,10 +137,7 @@ def _(mo):
     mo.vstack(
         [
             mo.md("## Run an AgentBot with MCP + Python tools"),
-            mo.md(
-                "Recommended default: **Anthropic Sonnet 4.5**. "
-                "LM Studio is also available for local testing."
-            ),
+            mo.md("Choose an Anthropic model option for this MCP tool-calling demo."),
             model_choice,
             user_query,
             run_agent,
@@ -152,7 +147,7 @@ def _(mo):
     return model_choice, run_agent, user_query
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(
     AgentBot,
     demo_mcp,
@@ -165,25 +160,13 @@ def _(
 ):
     mo.stop(not run_agent.value, mo.md("Click **Run AgentBot** to execute one run."))
 
-    api_kwargs = {}
     selected_model = model_choice.value
 
-    if selected_model == "anthropic/claude-sonnet-4-5-20250929":
-        if not os.environ.get("ANTHROPIC_API_KEY"):
-            mo.stop(True, mo.md(":warning: Set ANTHROPIC_API_KEY for Sonnet 4.5."))
-    elif selected_model == "openai/qwen/qwen3.6-35b-a3b":
-        lmstudio_api_base = os.environ.get(
-            "OPENAI_API_BASE", "http://localhost:1234/v1"
-        )
-        lmstudio_api_key = os.environ.get("OPENAI_API_KEY", "lm-studio")
-        api_kwargs = {
-            "api_base": lmstudio_api_base,
-            "api_key": lmstudio_api_key,
-        }
-        mo.output.append(mo.md(f"Using LM Studio endpoint: `{lmstudio_api_base}`"))
-    elif selected_model == "openai/gpt-4.1-mini":
-        if not os.environ.get("OPENAI_API_KEY"):
-            mo.stop(True, mo.md(":warning: Set OPENAI_API_KEY or switch models."))
+    if not selected_model.startswith("anthropic/"):
+        mo.stop(True, mo.md(":warning: Select an Anthropic model option."))
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        mo.stop(True, mo.md(":warning: Set ANTHROPIC_API_KEY for Anthropic models."))
 
     bot = AgentBot(
         tools=[local_uppercase],
@@ -194,14 +177,7 @@ def _(
         model_name=selected_model,
         max_iterations=8,
         mcp_servers=[demo_mcp],
-        **api_kwargs,
     )
-
-    # LM Studio + qwen/qwen3.6-35b-a3b may not emit structured tool_calls when
-    # ToolBot enforces tool_choice='required'. For this model, prefer auto.
-    if selected_model == "openai/qwen/qwen3.6-35b-a3b":
-        if hasattr(bot, "decide_node") and hasattr(bot.decide_node, "toolbot"):
-            bot.decide_node.toolbot.tool_choice = "auto"
 
     try:
         result = bot(user_query.value)
@@ -220,50 +196,21 @@ def _(
 
 @app.cell
 def _(mo):
-
     mo.md(
         r"""
-    ## Model and provider syntax cheatsheet
+    ## Anthropic model IDs in this notebook (LiteLLM)
 
-    ### Anthropic Sonnet 4.5 (recommended)
+    Based on LiteLLM docs / release notes, the dropdown uses:
 
-    - LiteLLM model id: `anthropic/claude-sonnet-4-5-20250929`
-    - Required env var: `ANTHROPIC_API_KEY`
-    - No custom `api_base` needed.
+    - Sonnet 4.5: `anthropic/claude-sonnet-4-5-20250929`
+    - Opus 4.5: `anthropic/claude-opus-4-5-20251101`
+    - Haiku 4.5 (latest): `anthropic/claude-haiku-4-5-20251001`
 
-    ### LM Studio (OpenAI-compatible local)
+    Set this environment variable before running:
 
     ```bash
-    export OPENAI_API_BASE=http://localhost:1234/v1
-    # Optional if your local gateway expects a key:
-    export OPENAI_API_KEY=lm-studio
+    export ANTHROPIC_API_KEY=...
     ```
-
-    Model string in this notebook: `openai/qwen/qwen3.6-35b-a3b`
-
-    ### Stdio MCP server
-
-    ```python
-    docs_spec = MCPServerSpec(
-        name="docs",
-        transport="stdio",
-        command="uvx",
-        args=["--with", "llamabot[all]", "llamabot", "mcp", "launch"],
-    )
-    ```
-
-    ### Remote HTTP / SSE MCP server
-
-    ```python
-    remote_spec = MCPServerSpec(
-        name="remote",
-        transport="http",  # or "sse"
-        url="http://localhost:8765/mcp",
-        headers={"Authorization": "Bearer TOKEN"},
-    )
-    ```
-
-    Use `MCPStartupMode.BEST_EFFORT` if some servers may be offline.
     """
     )
 

--- a/notebooks/mcp-tools.py
+++ b/notebooks/mcp-tools.py
@@ -47,7 +47,6 @@ def _(mo):
 
 @app.cell
 def _():
-
     import os
 
     from fastmcp import FastMCP
@@ -55,7 +54,6 @@ def _():
     from llamabot.bot.agentbot import AgentBot
     from llamabot.components.tools import tool
     from llamabot.mcp.manager import MCPClientManager
-    from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec, MCPStartupMode
 
     @tool
     def local_uppercase(text: str) -> str:
@@ -87,32 +85,12 @@ def _():
         """
         return a + b
 
-    return (
-        AgentBot,
-        MCPClientManager,
-        MCPIntegrationOptions,
-        MCPServerSpec,
-        MCPStartupMode,
-        demo_mcp,
-        local_uppercase,
-        os,
-    )
+    return AgentBot, MCPClientManager, demo_mcp, local_uppercase, os
 
 
 @app.cell
-def _(
-    MCPClientManager,
-    MCPIntegrationOptions,
-    MCPServerSpec,
-    MCPStartupMode,
-    demo_mcp,
-    mo,
-):
-
-    spec_preview = MCPServerSpec(name="demo", transport="inproc", fastmcp=demo_mcp)
-    opts_preview = MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT)
-
-    mgr = MCPClientManager([spec_preview], opts_preview)
+def _(MCPClientManager, demo_mcp, mo):
+    mgr = MCPClientManager([demo_mcp])
     mgr.start()
     try:
         wrapped = mgr.llamabot_tools()
@@ -177,9 +155,6 @@ def _(mo):
 @app.cell
 def _(
     AgentBot,
-    MCPIntegrationOptions,
-    MCPServerSpec,
-    MCPStartupMode,
     demo_mcp,
     local_uppercase,
     mo,
@@ -210,9 +185,6 @@ def _(
         if not os.environ.get("OPENAI_API_KEY"):
             mo.stop(True, mo.md(":warning: Set OPENAI_API_KEY or switch models."))
 
-    spec_agent = MCPServerSpec(name="demo", transport="inproc", fastmcp=demo_mcp)
-    opts_agent = MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT)
-
     bot = AgentBot(
         tools=[local_uppercase],
         system_prompt=(
@@ -221,8 +193,7 @@ def _(
         ),
         model_name=selected_model,
         max_iterations=8,
-        mcp_servers=[spec_agent],
-        mcp_options=opts_agent,
+        mcp_servers=[demo_mcp],
         **api_kwargs,
     )
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -21,6 +21,12 @@
       "sourceType": "github",
       "computedHash": "17f16170d948dd845121a49263493b534588db66457c9c47b40ad3868923cba7"
     },
+    "marimo-pair": {
+      "source": "marimo-team/marimo-pair",
+      "sourceType": "github",
+      "skillPath": "SKILL.md",
+      "computedHash": "f30a6602d88c5c785708e25d89cf390608fa4573989c28ea63a64696e85772ad"
+    },
     "wasm-compatibility": {
       "source": "marimo-team/skills",
       "sourceType": "github",

--- a/tests/bot/test_agentbot.py
+++ b/tests/bot/test_agentbot.py
@@ -472,6 +472,109 @@ def test_decide_node_uses_system_prompt():
         assert call_args.kwargs["system_prompt"] == custom_prompt
 
 
+def test_decide_node_queues_additional_tool_calls():
+    """Test that DecideNode queues multi-tool responses instead of dropping extras."""
+    from unittest.mock import MagicMock, patch
+
+    from llamabot.components.pocketflow.nodes import DecideNode
+
+    with patch("llamabot.bot.toolbot.ToolBot") as mock_toolbot_class:
+        mock_toolbot = MagicMock()
+        first_call = MagicMock()
+        first_call.function = MagicMock()
+        first_call.function.name = "demo__greet"
+        first_call.function.arguments = '{"name":"Ada"}'
+        second_call = MagicMock()
+        second_call.function = MagicMock()
+        second_call.function.name = "local_uppercase"
+        second_call.function.arguments = '{"text":"hello mcp"}'
+        mock_toolbot.return_value = [first_call, second_call]
+        mock_toolbot_class.return_value = mock_toolbot
+
+        decide_node = DecideNode(
+            tools=[],
+            system_prompt="Pick tools.",
+            model_name="anthropic/claude-sonnet-4-5-20250929",
+        )
+        prep_res = {"memory": ["Use both tools"], "globals_dict": {}}
+
+        first_selected = decide_node.exec(prep_res)
+        assert first_selected == "demo__greet"
+        assert prep_res["func_call"] == {"name": "Ada"}
+        assert prep_res["pending_tool_calls"] == [
+            {"name": "local_uppercase", "arguments": '{"text":"hello mcp"}'}
+        ]
+
+        second_selected = decide_node.exec(prep_res)
+        assert second_selected == "local_uppercase"
+        assert prep_res["func_call"] == {"text": "hello mcp"}
+        assert prep_res["pending_tool_calls"] == []
+
+        # The second selection should consume the queued call without another model request.
+        assert mock_toolbot.call_count == 1
+
+
+def test_decide_node_passes_execution_history_to_toolbot():
+    """Test that DecideNode forwards execution history into ToolBot context."""
+    from unittest.mock import MagicMock, patch
+
+    from llamabot.components.pocketflow.nodes import DecideNode
+
+    with patch("llamabot.bot.toolbot.ToolBot") as mock_toolbot_class:
+        mock_toolbot = MagicMock()
+        only_call = MagicMock()
+        only_call.function = MagicMock()
+        only_call.function.name = "respond_to_user"
+        only_call.function.arguments = '{"response":"done"}'
+        mock_toolbot.return_value = [only_call]
+        mock_toolbot_class.return_value = mock_toolbot
+
+        decide_node = DecideNode(
+            tools=[],
+            system_prompt="Pick tools.",
+            model_name="anthropic/claude-sonnet-4-5-20250929",
+        )
+        prep_res = {
+            "memory": ["Finish the task"],
+            "globals_dict": {},
+            "execution_history": [
+                {
+                    "tool_name": "demo__greet",
+                    "args": {"name": "Ada"},
+                    "result": "Hello, Ada!",
+                    "was_cached": False,
+                }
+            ],
+        }
+
+        selected = decide_node.exec(prep_res)
+        assert selected == "respond_to_user"
+        mock_toolbot.assert_called_once_with(
+            prep_res["memory"], execution_history=prep_res["execution_history"]
+        )
+
+
+def test_funcnode_post_records_execution_history():
+    """Test that tool-node post appends structured execution history."""
+    wrapped_tool = echo_function
+    shared = {"memory": []}
+    prep_result = {"func_call": {"text": "hello history"}}
+    exec_result = "hello history"
+
+    action = wrapped_tool.post(shared, prep_result, exec_result)
+
+    assert action == "decide"
+    assert shared["memory"][-1] == "hello history"
+    assert "execution_history" in shared
+    assert len(shared["execution_history"]) == 1
+    assert shared["execution_history"][0] == {
+        "tool_name": "echo_function",
+        "args": {"text": "hello history"},
+        "result": "hello history",
+        "was_cached": False,
+    }
+
+
 def test_agentbot_with_multiple_tools():
     """Test AgentBot with multiple user-provided tools."""
     bot = AgentBot(tools=[echo_function, add_function])

--- a/tests/bot/test_agentbot_mcp.py
+++ b/tests/bot/test_agentbot_mcp.py
@@ -1,5 +1,8 @@
 """Smoke tests for AgentBot MCP integration."""
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 from fastmcp import FastMCP
 
 from llamabot.bot.agentbot import AgentBot
@@ -11,6 +14,16 @@ from llamabot.mcp.specs import MCPServerSpec, MCPIntegrationOptions, MCPStartupM
 def local_stub() -> str:
     """Unused locally defined tool for AgentBot validation."""
     return "stub"
+
+
+@tool
+def local_uppercase(text: str) -> str:
+    """Uppercase text with a local Python tool.
+
+    :param text: Input text.
+    :return: Uppercased text.
+    """
+    return text.upper()
 
 
 def test_agentbot_merges_inproc_mcp_tools() -> None:
@@ -41,3 +54,94 @@ def test_agentbot_merges_inproc_mcp_tools() -> None:
         assert "srv__ping" in names
     finally:
         bot.close_mcp()
+
+
+def test_agentbot_notebook_like_mcp_flow_terminates_without_max_iterations() -> None:
+    """Mirror notebook behavior: MCP + local tool calls then respond naturally.
+
+    The first tool-selection call returns two tool calls in one model response
+    (MCP greet + local uppercase). The second selection call should receive
+    execution history and choose ``respond_to_user``.
+    """
+    mcp = FastMCP("agentbot_notebook_flow")
+
+    @mcp.tool()
+    def greet(name: str) -> str:
+        """Return a short greeting.
+
+        :param name: Who to greet.
+        :return: Greeting string.
+        """
+        return f"Hello, {name}! (from MCP tool greet)"
+
+    call_index = {"value": 0}
+    observed_history_lengths: list[int] = []
+
+    def select_tools(*messages, execution_history=None):
+        """Mock ToolBot callable used by DecideNode.
+
+        :param messages: Decision memory messages.
+        :param execution_history: Structured prior tool execution context.
+        :return: Tool-call objects with ``function.name`` and ``function.arguments``.
+        """
+        history = execution_history or []
+        observed_history_lengths.append(len(history))
+        call_index["value"] += 1
+
+        if call_index["value"] == 1:
+            return [
+                SimpleNamespace(
+                    function=SimpleNamespace(
+                        name="srv__greet",
+                        arguments='{"name":"Ada"}',
+                    )
+                ),
+                SimpleNamespace(
+                    function=SimpleNamespace(
+                        name="local_uppercase",
+                        arguments='{"text":"hello mcp"}',
+                    )
+                ),
+            ]
+
+        assert [entry["tool_name"] for entry in history[-2:]] == [
+            "srv__greet",
+            "local_uppercase",
+        ]
+        return [
+            SimpleNamespace(
+                function=SimpleNamespace(
+                    name="respond_to_user",
+                    arguments='{"response":"Done: greeted Ada and uppercased hello mcp."}',
+                )
+            )
+        ]
+
+    with patch("llamabot.bot.toolbot.ToolBot") as mock_toolbot_cls:
+        mock_toolbot = mock_toolbot_cls.return_value
+        mock_toolbot.side_effect = select_tools
+
+        bot = AgentBot(
+            tools=[local_uppercase],
+            mcp_servers=[MCPServerSpec(name="srv", transport="inproc", fastmcp=mcp)],
+            mcp_options=MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT),
+            model_name="anthropic/claude-sonnet-4-5-20250929",
+            max_iterations=8,
+            system_prompt=(
+                "You are a careful assistant. Prefer tools when useful. "
+                "MCP tools are namespaced (for example demo__greet)."
+            ),
+        )
+
+        try:
+            result = bot(
+                "Use MCP tool srv__greet to greet Ada, then use local_uppercase "
+                "on the phrase hello mcp."
+            )
+        finally:
+            bot.close_mcp()
+
+    assert result == "Done: greeted Ada and uppercased hello mcp."
+    assert call_index["value"] == 2
+    assert observed_history_lengths == [0, 2]
+    assert bot.shared["iteration_count"] == 3

--- a/tests/bot/test_agentbot_mcp.py
+++ b/tests/bot/test_agentbot_mcp.py
@@ -7,7 +7,7 @@ from fastmcp import FastMCP
 
 from llamabot.bot.agentbot import AgentBot
 from llamabot.components.tools import tool
-from llamabot.mcp.specs import MCPServerSpec, MCPIntegrationOptions, MCPStartupMode
+from llamabot.mcp.specs import MCPServerConfig, MCPIntegrationOptions, MCPStartupMode
 
 
 @tool
@@ -40,7 +40,7 @@ def test_agentbot_merges_inproc_mcp_tools() -> None:
 
     bot = AgentBot(
         tools=[local_stub],
-        mcp_servers=[MCPServerSpec(name="srv", transport="inproc", fastmcp=mcp)],
+        mcp_servers=[MCPServerConfig(name="srv", transport="inproc", fastmcp=mcp)],
         mcp_options=MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT),
         model_name="gpt-4o-mini",
     )
@@ -123,7 +123,7 @@ def test_agentbot_notebook_like_mcp_flow_terminates_without_max_iterations() -> 
 
         bot = AgentBot(
             tools=[local_uppercase],
-            mcp_servers=[MCPServerSpec(name="srv", transport="inproc", fastmcp=mcp)],
+            mcp_servers=[MCPServerConfig(name="srv", transport="inproc", fastmcp=mcp)],
             mcp_options=MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT),
             model_name="anthropic/claude-sonnet-4-5-20250929",
             max_iterations=8,

--- a/tests/bot/test_agentbot_mcp.py
+++ b/tests/bot/test_agentbot_mcp.py
@@ -1,0 +1,43 @@
+"""Smoke tests for AgentBot MCP integration."""
+
+from fastmcp import FastMCP
+
+from llamabot.bot.agentbot import AgentBot
+from llamabot.components.tools import tool
+from llamabot.mcp.specs import MCPServerSpec, MCPIntegrationOptions, MCPStartupMode
+
+
+@tool
+def local_stub() -> str:
+    """Unused locally defined tool for AgentBot validation."""
+    return "stub"
+
+
+def test_agentbot_merges_inproc_mcp_tools() -> None:
+    """AgentBot registers MCP-backed tools alongside Python tools."""
+    mcp = FastMCP("agentbot_mcp_test")
+
+    @mcp.tool()
+    def ping() -> str:
+        """Return pong.
+
+        :return: Literal pong.
+        """
+        return "pong"
+
+    bot = AgentBot(
+        tools=[local_stub],
+        mcp_servers=[MCPServerSpec(name="srv", transport="inproc", fastmcp=mcp)],
+        mcp_options=MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT),
+        model_name="gpt-4o-mini",
+    )
+    try:
+        names: list[str] = []
+        for t in bot.tools:
+            if hasattr(t, "func"):
+                names.append(t.func.__name__)
+            else:
+                names.append(getattr(t, "__name__", ""))
+        assert "srv__ping" in names
+    finally:
+        bot.close_mcp()

--- a/tests/mcp/test_adapter.py
+++ b/tests/mcp/test_adapter.py
@@ -1,0 +1,40 @@
+"""Tests for MCP schema adaptation helpers."""
+
+from llamabot.mcp.adapter import (
+    normalize_openai_parameters,
+    prefixed_tool_name,
+    remap_schema_properties_for_python,
+    sanitize_python_identifier,
+)
+
+
+def test_sanitize_python_identifier_replaces_invalid_chars() -> None:
+    """Hyphens and dots become underscores."""
+    assert sanitize_python_identifier("my-tool") == "my_tool"
+    assert sanitize_python_identifier("1st") == "_1st"
+
+
+def test_prefixed_tool_name_uses_separator() -> None:
+    """Prefixed names combine server and tool."""
+    assert prefixed_tool_name("srv", "add", "__") == "srv__add"
+
+
+def test_normalize_openai_parameters_empty() -> None:
+    """Missing schema yields empty object parameters."""
+    assert normalize_openai_parameters(None) == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
+
+
+def test_remap_schema_properties_keeps_wire_mapping() -> None:
+    """Wire JSON keys map to Python-safe parameter names."""
+    props = {"my-param": {"type": "string"}, "ok": {"type": "integer"}}
+    new_props, wire_map, req = remap_schema_properties_for_python(
+        props,
+        ["my-param"],
+    )
+    assert "my_param" in new_props
+    assert wire_map["my_param"] == "my-param"
+    assert "my_param" in req

--- a/tests/mcp/test_manager_integration.py
+++ b/tests/mcp/test_manager_integration.py
@@ -1,0 +1,51 @@
+"""Integration tests for MCP client manager with in-process FastMCP."""
+
+from fastmcp import FastMCP
+
+from llamabot.mcp.manager import MCPClientManager
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec, MCPStartupMode
+
+
+def test_inproc_mcp_tool_invoke_roundtrip() -> None:
+    """MCP tools discovered from an in-process server can be invoked synchronously."""
+    mcp = FastMCP("pytest_inline")
+
+    @mcp.tool()
+    def echo(text: str) -> str:
+        """Echo input unchanged.
+
+        :param text: Message to echo.
+        :return: Same text.
+        """
+        return text
+
+    spec = MCPServerSpec(name="pytest_srv", transport="inproc", fastmcp=mcp)
+    opts = MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT)
+    mgr = MCPClientManager([spec], opts)
+    try:
+        mgr.start()
+        tools = mgr.llamabot_tools()
+        names = {t.__name__ for t in tools}
+        assert "pytest_srv__echo" in names
+        echo_tool = next(t for t in tools if t.__name__ == "pytest_srv__echo")
+        assert echo_tool(text="hello") == "hello"
+    finally:
+        mgr.close()
+
+
+def test_best_effort_records_failure() -> None:
+    """Unreachable stdio server yields a failure entry without raising."""
+    spec = MCPServerSpec(
+        name="bad",
+        transport="stdio",
+        command="/nonexistent_binary_xyz",
+        args=[],
+    )
+    opts = MCPIntegrationOptions(startup_mode=MCPStartupMode.BEST_EFFORT)
+    mgr = MCPClientManager([spec], opts)
+    try:
+        mgr.start()
+        assert mgr.failures
+        assert mgr.llamabot_tools() == []
+    finally:
+        mgr.close()

--- a/tests/mcp/test_manager_integration.py
+++ b/tests/mcp/test_manager_integration.py
@@ -49,3 +49,27 @@ def test_best_effort_records_failure() -> None:
         assert mgr.llamabot_tools() == []
     finally:
         mgr.close()
+
+
+def test_inproc_fastmcp_shortcut_is_coerced() -> None:
+    """Passing FastMCP directly in ``mcp_servers`` is supported."""
+    mcp = FastMCP("shortcut_srv")
+
+    @mcp.tool()
+    def ping() -> str:
+        """Return pong.
+
+        :return: Literal pong.
+        """
+        return "pong"
+
+    mgr = MCPClientManager(
+        [mcp], MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT)
+    )
+    try:
+        mgr.start()
+        tools = mgr.llamabot_tools()
+        names = {tool.__name__ for tool in tools}
+        assert "shortcut_srv__ping" in names
+    finally:
+        mgr.close()

--- a/tests/mcp/test_manager_integration.py
+++ b/tests/mcp/test_manager_integration.py
@@ -3,7 +3,7 @@
 from fastmcp import FastMCP
 
 from llamabot.mcp.manager import MCPClientManager
-from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerSpec, MCPStartupMode
+from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerConfig, MCPStartupMode
 
 
 def test_inproc_mcp_tool_invoke_roundtrip() -> None:
@@ -19,9 +19,9 @@ def test_inproc_mcp_tool_invoke_roundtrip() -> None:
         """
         return text
 
-    spec = MCPServerSpec(name="pytest_srv", transport="inproc", fastmcp=mcp)
+    config = MCPServerConfig(name="pytest_srv", transport="inproc", fastmcp=mcp)
     opts = MCPIntegrationOptions(startup_mode=MCPStartupMode.STRICT)
-    mgr = MCPClientManager([spec], opts)
+    mgr = MCPClientManager([config], opts)
     try:
         mgr.start()
         tools = mgr.llamabot_tools()
@@ -35,14 +35,14 @@ def test_inproc_mcp_tool_invoke_roundtrip() -> None:
 
 def test_best_effort_records_failure() -> None:
     """Unreachable stdio server yields a failure entry without raising."""
-    spec = MCPServerSpec(
+    config = MCPServerConfig(
         name="bad",
         transport="stdio",
         command="/nonexistent_binary_xyz",
         args=[],
     )
     opts = MCPIntegrationOptions(startup_mode=MCPStartupMode.BEST_EFFORT)
-    mgr = MCPClientManager([spec], opts)
+    mgr = MCPClientManager([config], opts)
     try:
         mgr.start()
         assert mgr.failures


### PR DESCRIPTION
## Summary

This PR adds optional **MCP (FastMCP) client** integration so `AgentBot`, `AsyncAgentBot`, and `ToolBot` can merge Python `@tool` functions with tools discovered from MCP servers (stdio, HTTP/SSE/streamable HTTP, or in-process FastMCP for tests).

## Key changes

- New package `llamabot/mcp/`: `MCPServerSpec`, `MCPIntegrationOptions`, `MCPClientManager`, persistent session thread for async FastMCP clients, adapters producing LlamaBot-compatible tool nodes.
- Bots: `mcp_servers=`, `mcp_options=`, and `close_mcp()` for cleanup.
- Docs: `docs/how-to/agent-mcp-tools.md` (tracked with `git add -f` because `docs/how-to/*.md` is gitignored for generated marimo exports), `mkdocs.yaml` nav, `docs/reference/bots/agentbot.md` updates.
- Tests: `tests/mcp/`, `tests/bot/test_agentbot_mcp.py`.
- Agent skill: `.agents/skills/marimo-pair/` plus `skills-lock.json`; small `ears-syntax.md` reference tweak.

## Notes

- Pre-commit hooks expect full docstring coverage on nested helpers; pydoclint prefers constructor docs merged into class docstrings for these modules (addressed in `manager.py`, `session.py`, `adapter.py`).
- CI should run the full test suite; targeted MCP tests pass locally.

Made with [Cursor](https://cursor.com)