### PR TITLE
feat: lazy imports, restructured optional deps, precache command

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -145,3 +145,47 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           verbose: true
+
+  import-benchmark:
+    needs: check-changes
+    runs-on: ubuntu-latest
+    name: Import time benchmark
+    if: ${{ needs.check-changes.outputs.has-code-changes == 'true' && github.event_name == 'pull_request' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Pixi Environment
+        uses: prefix-dev/setup-pixi@v0.9.6
+        with:
+          pixi-version: v0.69.0
+          cache: true
+
+      - name: Run import benchmarks
+        run: pixi run python scripts/benchmark_imports.py --ci
+
+      - name: Build comment body
+        id: comment
+        run: |
+          python -c "
+          import json
+          with open('benchmark-results.json') as f:
+              results = json.load(f)
+          lines = ['| Import | Time |', '|---|---|']
+          for r in results:
+              t = r['time_s']
+              # Flag anything over 1s
+              marker = ' :warning:' if t > 1.0 else ''
+              lines.append(f\"| \`{r['label']}\` | {t:.3f}s{marker} |\")
+          body = chr(10).join(lines)
+          with open('comment-body.txt', 'w') as f:
+              f.write(body)
+          "
+
+      - name: Post import timings as PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: import-benchmark
+          path: comment-body.txt
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: interrogate
         args: [-c, pyproject.toml]
-        exclude: ^talks/|^talks/.+|talks/.*$|^notebooks/.*\.py$|^docs/examples/.*\.py$|^docs/how-to/.*\.py$|^tutorials/.*\.py$|^archive/.*\.py$
+        exclude: ^talks/|^talks/.+|talks/.*$|^notebooks/.*\.py$|^docs/examples/.*\.py$|^docs/how-to/.*\.py$|^tutorials/.*\.py$|^archive/.*\.py$|^scripts/.*\.py$|^tests/.*\.py$
   - repo: https://github.com/jsh9/pydoclint
     rev: 0.6.6
     hooks:

--- a/llamabot/__init__.py
+++ b/llamabot/__init__.py
@@ -4,7 +4,9 @@ This is the file from which you can do:
 
     from llamabot import some_function
 
-Use it to control the top-level API of your Python data science project.
+All bot classes, components, and utilities are lazily loaded via
+``lazy_loader`` so that ``import llamabot`` is near-instant.
+Heavy dependencies are only pulled in when you actually access a symbol.
 
 The module provides several high-level functions and classes for working with LLMs:
 
@@ -20,29 +22,7 @@ from pathlib import Path
 
 from loguru import logger
 
-from .bot.agentbot import AgentBot
-from .bot.async_agentbot import AsyncAgentBot
-from .bot.imagebot import ImageBot
-from .bot.querybot import AsyncQueryBot, QueryBot
-from .bot.simplebot import AsyncSimpleBot, SimpleBot
-from .bot.structuredbot import AsyncStructuredBot, StructuredBot
-from .bot.toolbot import AsyncToolBot, ToolBot
-from .components.chat_memory import ChatMemory
-from .components.docstore import BM25DocStore, LanceDBDocStore, TurboVecDocStore
-from .components.messages import dev, system, user
-from .components.pocketflow import nodeify
-from .components.tools import tool
-from .experiments import Experiment, metric
-from .prompt_manager import prompt
-from .recorder import (
-    SpanList,
-    dict_to_span,
-    enable_span_recording,
-    get_current_span,
-    get_span_tree,
-    get_spans,
-    span,
-)
+import lazy_loader
 
 
 def set_debug_mode(enabled: bool = True) -> None:
@@ -58,7 +38,6 @@ def set_debug_mode(enabled: bool = True) -> None:
     logger.add(lambda msg: print(msg, end=""), level=level)
 
 
-# Configure logger
 log_level = os.getenv("LOG_LEVEL", "WARNING").upper()
 level_map = {
     "DEBUG": "DEBUG",
@@ -68,42 +47,38 @@ level_map = {
     "CRITICAL": "CRITICAL",
 }
 
-# Remove default logger configuration and set the desired level
 logger.add(lambda msg: print(msg, end=""), level=level_map.get(log_level, "WARNING"))
 
-__all__ = [
-    "AgentBot",
-    "AsyncAgentBot",
-    "AsyncQueryBot",
-    "AsyncSimpleBot",
-    "AsyncStructuredBot",
-    "AsyncToolBot",
-    "ImageBot",
-    "SimpleBot",
-    "QueryBot",
-    "StructuredBot",
-    "ToolBot",
-    "prompt",
-    "Experiment",
-    "metric",
-    "tool",
-    "user",
-    "system",
-    "dev",
-    "BM25DocStore",
-    "LanceDBDocStore",
-    "TurboVecDocStore",
-    "set_debug_mode",
-    "ChatMemory",
-    "nodeify",
-    "span",
-    "get_current_span",
-    "get_spans",
-    "get_span_tree",
-    "enable_span_recording",
-    "dict_to_span",
-    "SpanList",
-]
+__getattr__, __dir__, __all__ = lazy_loader.attach(
+    __name__,
+    submodules=[],
+    submod_attrs={
+        "bot.agentbot": ["AgentBot"],
+        "bot.async_agentbot": ["AsyncAgentBot"],
+        "bot.imagebot": ["ImageBot"],
+        "bot.querybot": ["AsyncQueryBot", "QueryBot"],
+        "bot.simplebot": ["AsyncSimpleBot", "SimpleBot"],
+        "bot.structuredbot": ["AsyncStructuredBot", "StructuredBot"],
+        "bot.toolbot": ["AsyncToolBot", "ToolBot"],
+        "components.chat_memory": ["ChatMemory"],
+        "components.docstore": ["BM25DocStore", "LanceDBDocStore", "TurboVecDocStore"],
+        "components.messages": ["dev", "system", "user"],
+        "components.pocketflow": ["nodeify"],
+        "components.tools": ["tool"],
+        "experiments": ["Experiment", "metric"],
+        "prompt_manager": ["prompt"],
+        "recorder": [
+            "SpanList",
+            "dict_to_span",
+            "enable_span_recording",
+            "get_current_span",
+            "get_span_tree",
+            "get_spans",
+            "span",
+        ],
+    },
+)
 
-# Ensure ~/.llamabot directory exists
+__all__.append("set_debug_mode")
+
 (Path.home() / ".llamabot").mkdir(parents=True, exist_ok=True)

--- a/llamabot/bot/agentbot.py
+++ b/llamabot/bot/agentbot.py
@@ -6,14 +6,9 @@ The bot uses a decision-making node to determine which tools to call
 and in what order, making it suitable for complex, multi-step tasks.
 """
 
+from __future__ import annotations
+
 from typing import Callable, List, Optional
-
-from pocketflow import Flow, Node
-
-from llamabot.components.pocketflow import DecideNode
-from llamabot.components.tools import DEFAULT_TOOLS
-from llamabot.mcp.manager import MCPClientManager
-from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerConfig
 
 
 def _validate_tools(tools: List[Callable]) -> None:
@@ -119,15 +114,20 @@ class AgentBot:
     def __init__(
         self,
         tools: List[Callable],
-        decide_node: Optional[Node] = None,
+        decide_node=None,
         system_prompt: Optional[str] = None,
         model_name: str = "gpt-4.1",
         max_iterations: Optional[int] = None,
-        mcp_servers: Optional[List[MCPServerConfig]] = None,
-        mcp_options: Optional[MCPIntegrationOptions] = None,
+        mcp_servers=None,
+        mcp_options=None,
         **completion_kwargs,
     ):
-        self._mcp_manager: MCPClientManager | None = None
+        from llamabot.components.pocketflow import DecideNode
+        from llamabot.components.tools import DEFAULT_TOOLS
+        from llamabot.mcp.manager import MCPClientManager
+        from pocketflow import Flow
+
+        self._mcp_manager = None
         mcp_tool_list: List[Callable] = []
         if mcp_servers:
             self._mcp_manager = MCPClientManager(mcp_servers, mcp_options)

--- a/llamabot/bot/simplebot.py
+++ b/llamabot/bot/simplebot.py
@@ -1,10 +1,13 @@
 """Class definition for SimpleBot and :class:`AsyncSimpleBot`."""
 
+from __future__ import annotations
+
 import contextvars
 import json
 import uuid
 from types import NoneType
 from typing import (
+    TYPE_CHECKING,
     AsyncGenerator,
     Callable,
     Generator,
@@ -13,13 +16,6 @@ from typing import (
     Union,
 )
 
-from litellm import (
-    ChatCompletionMessageToolCall,
-    CustomStreamWrapper,
-    Function,
-    ModelResponse,
-    stream_chunk_builder,
-)
 from loguru import logger
 from pydantic import BaseModel
 
@@ -32,14 +28,11 @@ from llamabot.components.messages import (
     to_basemessage,
 )
 from llamabot.config import default_language_model
-from llamabot.recorder import (
-    Span,
-    SpanList,
-    get_caller_variable_name,
-    get_current_span,
-    get_spans,
-    sqlite_log,
-)
+
+if TYPE_CHECKING:
+    from litellm import CustomStreamWrapper, ModelResponse
+
+    from llamabot.recorder import Span, SpanList
 
 prompt_recorder_var = contextvars.ContextVar("prompt_recorder")
 
@@ -174,18 +167,23 @@ class SimpleBot:
         :return: The response to the human messages, primed by the system prompt.
         """
         # Create outer span for the entire bot call
+        from llamabot.recorder import (
+            Span,
+            get_caller_variable_name,
+            get_current_span,
+            sqlite_log,
+        )
+
         query_content = " ".join(
             [
                 msg.content if hasattr(msg, "content") else str(msg)
                 for msg in human_messages
             ]
         )
-        # Try to get the variable name from the calling frame
         operation_name = get_caller_variable_name(self)
         if operation_name is None:
             operation_name = "simplebot_call"
 
-        # Check if there's a current span - if so, create a child span
         current_span = get_current_span()
         if current_span:
             # Create child span using parent's trace_id
@@ -257,9 +255,12 @@ class SimpleBot:
         :return: SpanList containing all spans from this bot instance
         """
         if not self._trace_ids:
+            from llamabot.recorder import SpanList
+
             return SpanList([])
 
-        # Collect all spans from all trace_ids for this bot instance
+        from llamabot.recorder import SpanList, get_spans
+
         all_spans_objects = []
         for trace_id in self._trace_ids:
             spans = get_spans(trace_id=trace_id)
@@ -467,6 +468,8 @@ async def stream_tokens_for_messages(
     response = await make_async_response(bot, messages, stream=stream)
     chunks: list = []
 
+    from litellm import ModelResponse, stream_chunk_builder
+
     if isinstance(response, ModelResponse):
         if finalize:
             finalize(response)
@@ -505,6 +508,8 @@ def stream_chunks(
     :return: The response from the `completion` call.
     """
     # Pass through if it's already a ModelResponse
+    from litellm import ModelResponse, stream_chunk_builder
+
     if isinstance(response, ModelResponse):
         return response
 
@@ -564,6 +569,8 @@ async def async_stream_chunks(
     if isinstance(response, ModelResponse):
         return response
 
+    from litellm import stream_chunk_builder
+
     chunks: list = []
     async for chunk in response:
         chunks.append(chunk)
@@ -604,7 +611,7 @@ def serialize_tool_arguments(args: Union[dict, str, None]) -> str:
     return json.dumps(args)
 
 
-def extract_tool_calls(response: ModelResponse) -> list[ChatCompletionMessageToolCall]:
+def extract_tool_calls(response) -> list:
     """Extract the tool calls from the response.
 
     Handles both structured tool_calls (OpenAI-style) and JSON in content field
@@ -613,6 +620,8 @@ def extract_tool_calls(response: ModelResponse) -> list[ChatCompletionMessageToo
     :param response: The response from a `completion` call.
     :return: A list of tool calls.
     """
+    from litellm import ChatCompletionMessageToolCall, Function
+
     message = response.choices[0].message
     tool_calls: List[ChatCompletionMessageToolCall] | NoneType = message.tool_calls
 
@@ -682,7 +691,7 @@ def extract_tool_calls(response: ModelResponse) -> list[ChatCompletionMessageToo
     return []
 
 
-def extract_content(response: ModelResponse) -> str:
+def extract_content(response) -> str:
     """Extract the content from the response.
 
     :param response: The response from a `completion` call.
@@ -702,6 +711,8 @@ class AsyncSimpleBot(SimpleBot):
         *human_messages: Union[str, BaseMessage, list[Union[str, BaseMessage]]],
     ) -> AsyncGenerator[str, None]:
         """Stream assistant text deltas (same inputs as :meth:`SimpleBot.__call__`)."""
+        from llamabot.recorder import sqlite_log
+
         messages, processed_messages = self.compose_messages_for_human_messages(
             *human_messages
         )
@@ -729,6 +740,13 @@ class AsyncSimpleBot(SimpleBot):
         *human_messages: Union[str, BaseMessage, list[Union[str, BaseMessage]]],
     ) -> AIMessage:
         """Async completion: same role as :meth:`SimpleBot.__call__`."""
+        from llamabot.recorder import (
+            Span,
+            get_caller_variable_name,
+            get_current_span,
+            sqlite_log,
+        )
+
         query_content = " ".join(
             [
                 msg.content if hasattr(msg, "content") else str(msg)

--- a/llamabot/bot/simplebot.py
+++ b/llamabot/bot/simplebot.py
@@ -566,10 +566,10 @@ async def async_stream_chunks(
     :param target: Same semantics as :func:`stream_chunks` (``stdout``, ``panel``, ``api``).
     :return: A fully assembled :class:`ModelResponse`.
     """
+    from litellm import ModelResponse, stream_chunk_builder
+
     if isinstance(response, ModelResponse):
         return response
-
-    from litellm import stream_chunk_builder
 
     chunks: list = []
     async for chunk in response:

--- a/llamabot/cli/__init__.py
+++ b/llamabot/cli/__init__.py
@@ -101,5 +101,18 @@ def clear_cache():
     os.system("rm -rf {}".format(CACHE_DIR))
 
 
+@app.command()
+def precache():
+    """Pre-download the default embedding model for RAG.
+
+    This avoids the first-run download penalty (~60 MB).
+    Useful inside Docker containers or CI environments.
+    Requires the ``rag`` extra: ``pip install llamabot[rag]``.
+    """
+    from llamabot.precache import precache_embedding_model
+
+    precache_embedding_model()
+
+
 if __name__ == "__main__":
     app()

--- a/llamabot/components/chat_memory/memory.py
+++ b/llamabot/components/chat_memory/memory.py
@@ -1,14 +1,12 @@
 """Main ChatMemory class for unified chat memory system."""
 
 import json
-import networkx as nx
 from typing import List, Optional
 from datetime import datetime
 from llamabot.components.messages import (
     BaseMessage,
     AIMessage,
 )
-from llamabot.bot.structuredbot import StructuredBot
 from llamabot.components.chat_memory.models import ConversationNode, MessageSummary
 from llamabot.components.chat_memory.selectors import (
     NodeSelector,
@@ -24,23 +22,26 @@ from llamabot.components.chat_memory.retrieval import (
     semantic_search_with_context,
 )
 from llamabot.components.chat_memory.visualization import to_mermaid
-from llamabot.prompt_manager import prompt
 
 
-@prompt("system")
 def message_summarizer_system_prompt() -> str:
-    """You are an expert at summarizing messages. Create concise, informative summaries that capture the key points and intent of each message.
+    """Return the system prompt for the message summarizer.
 
-    Your task is to analyze the content of a message and provide:
-    1. A clear, descriptive title that captures the main topic
-    2. A concise summary (maximum two sentences) that highlights the key points
-
-    Focus on:
-    - The main intent or purpose of the message
-    - Key concepts or topics discussed
-    - Any specific requests or questions
-    - Important details that would be useful for conversation threading
+    :return: The system prompt string.
     """
+    return """\
+You are an expert at summarizing messages. Create concise, informative summaries that capture the key points and intent of each message.
+
+Your task is to analyze the content of a message and provide:
+1. A clear, descriptive title that captures the main topic
+2. A concise summary (maximum two sentences) that highlights the key points
+
+Focus on:
+- The main intent or purpose of the message
+- Key concepts or topics discussed
+- Any specific requests or questions
+- Important details that would be useful for conversation threading
+"""
 
 
 class Summarizer:
@@ -62,6 +63,8 @@ class LLMSummarizer(Summarizer):
     """
 
     def __init__(self, model: str = "gpt-4o-mini"):
+        from llamabot.bot.structuredbot import StructuredBot
+
         self.model = model
         self.bot = StructuredBot(
             system_prompt=message_summarizer_system_prompt(),
@@ -100,6 +103,8 @@ class ChatMemory:
         context_depth: int = 5,
     ):
         # Initialize NetworkX graph for storage
+        import networkx as nx
+
         self.graph = nx.DiGraph()
 
         # Set node selector (linear by default, LLM-based if provided)

--- a/llamabot/components/chat_memory/retrieval.py
+++ b/llamabot/components/chat_memory/retrieval.py
@@ -1,8 +1,13 @@
 """Retrieval functions for chat memory."""
 
-import networkx as nx
-from typing import List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
 from llamabot.components.messages import BaseMessage
+
+if TYPE_CHECKING:
+    import networkx as nx
 
 
 def get_recent_messages(graph: nx.DiGraph, n_results: int) -> List[BaseMessage]:

--- a/llamabot/components/chat_memory/selectors.py
+++ b/llamabot/components/chat_memory/selectors.py
@@ -1,13 +1,16 @@
 """Node selection strategies for chat memory."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import List, Optional
-import networkx as nx
+from typing import TYPE_CHECKING, List, Optional
+
 from pydantic import BaseModel, Field, model_validator
 from llamabot.components.messages import BaseMessage
-from llamabot.bot.structuredbot import StructuredBot
-from llamabot.prompt_manager import prompt
 from loguru import logger
+
+if TYPE_CHECKING:
+    import networkx as nx
 
 
 def get_candidate_nodes(graph: nx.DiGraph) -> List[int]:
@@ -72,24 +75,34 @@ def validate_node_selection(
         return False
 
 
-@prompt("system")
-def node_selection_system_prompt(candidate_nodes: str):
-    """You are an expert at analyzing conversation threads and selecting the most appropriate parent node for new messages.
+def node_selection_system_prompt(candidate_nodes: str) -> str:
+    """Generate the system prompt for node selection.
 
-    Your task is to examine the conversation context and choose which existing assistant message should be the parent of a new user message.
-
-    Consider:
-    1. Direct topic continuation - if the new message directly continues a topic
-    2. Related concepts - if the new message relates to concepts discussed in a previous message
-    3. Temporal relevance - recent messages are often more relevant than older ones
-    4. Contextual flow - maintain logical conversation flow
-
-    You must select a valid assistant node ID from the provided candidates.
-
-    Available candidate nodes: {{candidate_nodes}}
-
-    If your selection is invalid, you will receive feedback and must try again with a valid node ID.
+    :param candidate_nodes: Comma-separated string of candidate node IDs
+    :return: The rendered system prompt string
     """
+    from llamabot.prompt_manager import prompt
+
+    @prompt("system")
+    def _prompt(candidate_nodes: str):
+        """You are an expert at analyzing conversation threads and selecting the most appropriate parent node for new messages.
+
+        Your task is to examine the conversation context and choose which existing assistant message should be the parent of a new user message.
+
+        Consider:
+        1. Direct topic continuation - if the new message directly continues a topic
+        2. Related concepts - if the new message relates to concepts discussed in a previous message
+        3. Temporal relevance - recent messages are often more relevant than older ones
+        4. Contextual flow - maintain logical conversation flow
+
+        You must select a valid assistant node ID from the provided candidates.
+
+        Available candidate nodes: {{candidate_nodes}}
+
+        If your selection is invalid, you will receive feedback and must try again with a valid node ID.
+        """
+
+    return _prompt(candidate_nodes)
 
 
 class NodeSelection(BaseModel):
@@ -192,6 +205,8 @@ class LLMNodeSelector(NodeSelector):
         system_prompt = node_selection_system_prompt(candidate_nodes_str)
 
         if self.bot is None or self.bot.system_prompt != system_prompt:
+            from llamabot.bot.structuredbot import StructuredBot
+
             self.bot = StructuredBot(
                 system_prompt=system_prompt,
                 pydantic_model=NodeSelection,

--- a/llamabot/components/chat_memory/storage.py
+++ b/llamabot/components/chat_memory/storage.py
@@ -1,7 +1,9 @@
 """Storage functions for chat memory."""
 
-import networkx as nx
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Union
+
 from llamabot.components.messages import (
     BaseMessage,
     HumanMessage,
@@ -11,6 +13,9 @@ from llamabot.components.messages import (
 )
 from llamabot.components.chat_memory.models import ConversationNode
 from llamabot.components.chat_memory.selectors import NodeSelector
+
+if TYPE_CHECKING:
+    import networkx as nx
 
 
 def append_linear(

--- a/llamabot/components/chat_memory/visualization.py
+++ b/llamabot/components/chat_memory/visualization.py
@@ -1,6 +1,11 @@
 """Visualization functions for chat memory."""
 
-import networkx as nx
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import networkx as nx
 
 
 def to_mermaid(graph: nx.DiGraph, **kwargs) -> str:

--- a/llamabot/components/tools.py
+++ b/llamabot/components/tools.py
@@ -19,18 +19,7 @@ from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from uuid import uuid4
 
-import requests
-from bs4 import BeautifulSoup
-from docstring_parser import parse
-from duckduckgo_search.exceptions import DuckDuckGoSearchException
 from loguru import logger
-
-from llamabot.bot.simplebot import SimpleBot
-from llamabot.components.messages import user
-from llamabot.components.pocketflow import nodeify as nodeify_decorator
-from llamabot.components.sandbox import ScriptExecutor, ScriptMetadata
-from llamabot.prompt_manager import prompt
-from llamabot.recorder import span as span_decorator
 
 
 def json_schema_type(type_name: str) -> str:
@@ -112,7 +101,8 @@ def function_to_dict(input_function: Callable) -> Dict[str, Any]:
     name = input_function.__name__
     docstring = inspect.getdoc(input_function) or ""
 
-    # Parse docstring
+    from docstring_parser import parse
+
     parsed = parse(docstring)
 
     # Combine short and long descriptions
@@ -276,6 +266,8 @@ def tool(
 
         # Apply @span decorator if enabled
         if span:
+            from llamabot.recorder import span as span_decorator
+
             wrapper = span_decorator(
                 operation_name=operation_name,
                 exclude_args=exclude_args,
@@ -283,6 +275,8 @@ def tool(
             )(wrapper)
 
         # Always apply AgentBot integration
+        from llamabot.components.pocketflow import nodeify as nodeify_decorator
+
         wrapper = nodeify_decorator(loopback_name=loopback_name)(wrapper)
 
         return wrapper
@@ -377,7 +371,7 @@ def search_internet(search_term: str, max_results: int = 10) -> Dict[str, str]:
         from duckduckgo_search import DDGS
     except ImportError:
         raise ImportError(
-            "The Python package `duckduckgo_search` cannot be found. Please install it using `pip install llamabot[agent]`."
+            "The Python package `duckduckgo_search` cannot be found. Please install it using `pip install llamabot[tools]`."
         )
 
     try:
@@ -386,6 +380,8 @@ def search_internet(search_term: str, max_results: int = 10) -> Dict[str, str]:
         raise ImportError(
             "The Python package `markdownify` cannot be found. Please install it using `pip install llamabot[agent]`."
         )
+
+    from duckduckgo_search.exceptions import DuckDuckGoSearchException
 
     def perform_search(ddgs, search_term, max_results):
         """
@@ -464,6 +460,9 @@ def search_internet(search_term: str, max_results: int = 10) -> Dict[str, str]:
         :return: The content of the URL
         """
         try:
+            import requests
+            from bs4 import BeautifulSoup
+
             response = requests.get(url, headers=headers, timeout=10)
             soup = BeautifulSoup(response.text, "html.parser")
             return url, md(soup.get_text())
@@ -483,47 +482,50 @@ def search_internet(search_term: str, max_results: int = 10) -> Dict[str, str]:
     return webpage_contents
 
 
-@prompt("system")
 def summarization_bot_system_prompt() -> str:
+    """Return the system prompt for the summarization bot.
+
+    :return: The system prompt string.
     """
-    ## role
+    return """\
+## role
 
-    You are a precise summarization assistant that creates focused, relevant summaries of web content.
-    Your job is to extract and synthesize the most important information based on the user's query.
+You are a precise summarization assistant that creates focused, relevant summaries of web content.
+Your job is to extract and synthesize the most important information based on the user's query.
 
-    ## summarization guidelines
+## summarization guidelines
 
-    1. Focus on relevance:
-       - Prioritize information directly related to the search term
-       - Filter out tangential or unrelated content
-       - Maintain context while being concise
+1. Focus on relevance:
+   - Prioritize information directly related to the search term
+   - Filter out tangential or unrelated content
+   - Maintain context while being concise
 
-    2. Structure your summary:
-       - Start with the most relevant information
-       - Include key facts, figures, or findings
-       - End with any important implications or conclusions
+2. Structure your summary:
+   - Start with the most relevant information
+   - Include key facts, figures, or findings
+   - End with any important implications or conclusions
 
-    3. Quality standards:
-       - Be factual and objective
-       - Preserve critical context
-       - Avoid redundancy
-       - Use clear, professional language
-       - Keep to one focused paragraph
+3. Quality standards:
+   - Be factual and objective
+   - Preserve critical context
+   - Avoid redundancy
+   - Use clear, professional language
+   - Keep to one focused paragraph
 
-    4. When information is missing or unclear:
-       - Acknowledge gaps explicitly
-       - Don't make assumptions
-       - Focus on what is known with confidence
+4. When information is missing or unclear:
+   - Acknowledge gaps explicitly
+   - Don't make assumptions
+   - Focus on what is known with confidence
 
-    ## output format
+## output format
 
-    Your summary should be:
-    - One paragraph (3-5 sentences)
-    - Directly relevant to the search term
-    - Self-contained and clear
-    - Professional in tone
-    - Free of unnecessary qualifiers or hedging
-    """
+Your summary should be:
+- One paragraph (3-5 sentences)
+- Directly relevant to the search term
+- Self-contained and clear
+- Professional in tone
+- Free of unnecessary qualifiers or hedging
+"""
 
 
 def summarize_web_results(
@@ -535,6 +537,8 @@ def summarize_web_results(
     :param webpage_contents: The content of the webpage
     :return: The summarized content
     """
+    from llamabot.bot.simplebot import SimpleBot
+
     default_model_name = os.getenv(
         "LMB_INTERNET_SUMMARIZER_MODEL_NAME", "ollama_chat/llama3.1:latest"
     )
@@ -556,6 +560,8 @@ def summarize_web_results(
         :return: The summarized content
         """
         logger.debug("Summarizing {}:", url)
+        from llamabot.components.messages import user
+
         return url, bot(user(f"Query: {search_term}"), user(content)).content
 
     summaries = {}
@@ -689,6 +695,8 @@ def write_and_execute_script(
     :param python_version: Python version requirement. Should look like ">=3.11"
     :return: Dictionary containing script execution results
     """
+    from llamabot.components.sandbox import ScriptExecutor, ScriptMetadata
+
     # Parse dependencies string into list
     dependencies = list(
         dep.strip()

--- a/llamabot/mcp/session.py
+++ b/llamabot/mcp/session.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import asyncio
 import threading
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from fastmcp import Client
-from fastmcp.mcp_config import RemoteMCPServer, StdioMCPServer
-
 from llamabot.mcp.specs import MCPIntegrationOptions, MCPServerConfig
+
+if TYPE_CHECKING:
+    from fastmcp import Client
 
 
 def build_fastmcp_client(
@@ -24,6 +24,9 @@ def build_fastmcp_client(
     :param options: Integration timeouts and client options.
     :return: Configured FastMCP client (not yet connected).
     """
+    from fastmcp import Client
+    from fastmcp.mcp_config import StdioMCPServer
+
     kwargs: dict[str, Any] = {}
     if options.client_timeout_seconds is not None:
         kwargs["timeout"] = timedelta(seconds=float(options.client_timeout_seconds))
@@ -41,6 +44,9 @@ def build_fastmcp_client(
             cwd=config.cwd,
         )
         return Client(stdio.to_transport(), name=config.name, **kwargs)
+
+    from fastmcp import Client
+    from fastmcp.mcp_config import RemoteMCPServer
 
     remote_transport: str | None
     if config.remote_transport is not None:

--- a/llamabot/precache.py
+++ b/llamabot/precache.py
@@ -1,0 +1,23 @@
+"""Pre-cache utilities for llamabot embedding models."""
+
+DEFAULT_MODEL = "minishlab/potion-base-8M"
+
+
+def precache_embedding_model(model_name: str = DEFAULT_MODEL) -> str:
+    """Download and cache *model_name* if not already present.
+
+    :param model_name: HuggingFace model identifier.
+    :return: The model name that was cached.
+    """
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError:
+        raise ImportError(
+            "sentence-transformers is not installed. "
+            "Install it with: pip install llamabot[rag]"
+        )
+
+    print(f"Pre-caching embedding model: {model_name}")
+    SentenceTransformer(model_name, trust_remote_code=True)
+    print(f"Done — {model_name} is now cached locally.")
+    return model_name

--- a/pixi.lock
+++ b/pixi.lock
@@ -54,6 +54,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -251,6 +253,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d9/5d/ad86864477be969dc9f934ef2c10c515096ba69790068df77605c989709e/turbovec-0.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d9/7d/9c8a781c88933725445a859cac5d01b5871588a15969ee6aeb618ba99eee/numpy-2.4.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/da/a2/d32ab58c0b216912638b140ab2170ee4b8644067c293b170e19fba340ccc/types_toml-0.10.8.20240310-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/0f/0d52c98b8a885aeda831224b78f3be7ec2e1aa4a62091f9f9188c3c65b56/yarl-1.22.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -323,6 +326,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -504,6 +509,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cb/bd/1a875e0d592d447cbc02805fd3fe0f497714d6a2583f59d14fa9ebad96eb/huggingface_hub-0.36.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/42/08535de942011b644dc4ca856082bbe7365f6244ae2b80afe55bc4f76225/turbovec-0.7.0-cp39-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
@@ -549,6 +555,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -761,6 +769,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/ed/f3b81ca8743d69b95d679b95e6e1d22cb7cc678ae77c6a57827303a7e48c/rerankers-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/f6/adbdaca6f0023a0d1887a63c332f37938644c714989af51c779fadb42b80/turbovec-0.7.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl
@@ -792,6 +801,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -951,6 +962,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/17/20c2552266728ceba271967b87919664ecc0e33efca29c3efc6baf88c5f9/ipykernel-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/55/5e0c31ccbde716859ec81a8c4dc197973c40e0519a54778b26121d5f8056/turbovec-0.7.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl
@@ -1036,6 +1048,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -1160,6 +1174,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6c/79/3912a94cf27ec503e51ba493692d6db1e3cd8ac7ac52b0b47c8e33d7f4f9/greenlet-3.3.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6e/78/a850fed8aeef96d4a99043c90b818b2ed5419cd5b24a4049fd7cfb9f1471/fakeredis-2.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/76/9a/1f8d8acfe5666871b794047ffcb7312b3d720e277c9d395dbaf7d79e3b1f/turbovec-0.7.0-cp39-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl
@@ -1318,6 +1333,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
@@ -1538,6 +1555,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/07/c115a27adb5228bdf78d0c2366637c5b1630427f879c674f7bab4e6eb637/tuna-0.5.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d9/5d/ad86864477be969dc9f934ef2c10c515096ba69790068df77605c989709e/turbovec-0.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d9/7d/9c8a781c88933725445a859cac5d01b5871588a15969ee6aeb618ba99eee/numpy-2.4.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/da/a2/d32ab58c0b216912638b140ab2170ee4b8644067c293b170e19fba340ccc/types_toml-0.10.8.20240310-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/0f/0d52c98b8a885aeda831224b78f3be7ec2e1aa4a62091f9f9188c3c65b56/yarl-1.22.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -1621,6 +1639,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
@@ -1825,6 +1845,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/42/08535de942011b644dc4ca856082bbe7365f6244ae2b80afe55bc4f76225/turbovec-0.7.0-cp39-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/07/c115a27adb5228bdf78d0c2366637c5b1630427f879c674f7bab4e6eb637/tuna-0.5.11-py3-none-any.whl
@@ -1881,6 +1902,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
@@ -2117,6 +2140,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/ed/f3b81ca8743d69b95d679b95e6e1d22cb7cc678ae77c6a57827303a7e48c/rerankers-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/f6/adbdaca6f0023a0d1887a63c332f37938644c714989af51c779fadb42b80/turbovec-0.7.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl
@@ -2158,6 +2182,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
@@ -2337,6 +2363,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/17/20c2552266728ceba271967b87919664ecc0e33efca29c3efc6baf88c5f9/ipykernel-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/55/5e0c31ccbde716859ec81a8c4dc197973c40e0519a54778b26121d5f8056/turbovec-0.7.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl
@@ -2436,6 +2463,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
@@ -2575,6 +2604,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6e/78/a850fed8aeef96d4a99043c90b818b2ed5419cd5b24a4049fd7cfb9f1471/fakeredis-2.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/76/9a/1f8d8acfe5666871b794047ffcb7312b3d720e277c9d395dbaf7d79e3b1f/turbovec-0.7.0-cp39-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl
@@ -2746,6 +2776,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -2954,6 +2986,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d9/5d/ad86864477be969dc9f934ef2c10c515096ba69790068df77605c989709e/turbovec-0.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d9/7d/9c8a781c88933725445a859cac5d01b5871588a15969ee6aeb618ba99eee/numpy-2.4.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/da/a2/d32ab58c0b216912638b140ab2170ee4b8644067c293b170e19fba340ccc/types_toml-0.10.8.20240310-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/0f/0d52c98b8a885aeda831224b78f3be7ec2e1aa4a62091f9f9188c3c65b56/yarl-1.22.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -3030,6 +3063,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -3222,6 +3257,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/42/08535de942011b644dc4ca856082bbe7365f6244ae2b80afe55bc4f76225/turbovec-0.7.0-cp39-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
@@ -3271,6 +3307,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -3493,6 +3531,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/ed/f3b81ca8743d69b95d679b95e6e1d22cb7cc678ae77c6a57827303a7e48c/rerankers-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/f6/adbdaca6f0023a0d1887a63c332f37938644c714989af51c779fadb42b80/turbovec-0.7.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl
@@ -3529,6 +3568,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -3697,6 +3738,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/17/20c2552266728ceba271967b87919664ecc0e33efca29c3efc6baf88c5f9/ipykernel-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/55/5e0c31ccbde716859ec81a8c4dc197973c40e0519a54778b26121d5f8056/turbovec-0.7.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl
@@ -3788,6 +3830,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -3917,6 +3961,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6e/78/a850fed8aeef96d4a99043c90b818b2ed5419cd5b24a4049fd7cfb9f1471/fakeredis-2.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/76/9a/1f8d8acfe5666871b794047ffcb7312b3d720e277c9d395dbaf7d79e3b1f/turbovec-0.7.0-cp39-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl
@@ -4082,6 +4127,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -4272,6 +4319,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d9/5d/ad86864477be969dc9f934ef2c10c515096ba69790068df77605c989709e/turbovec-0.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d9/7d/9c8a781c88933725445a859cac5d01b5871588a15969ee6aeb618ba99eee/numpy-2.4.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/da/a2/d32ab58c0b216912638b140ab2170ee4b8644067c293b170e19fba340ccc/types_toml-0.10.8.20240310-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/0f/0d52c98b8a885aeda831224b78f3be7ec2e1aa4a62091f9f9188c3c65b56/yarl-1.22.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -4344,6 +4392,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -4518,6 +4568,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cb/bd/1a875e0d592d447cbc02805fd3fe0f497714d6a2583f59d14fa9ebad96eb/huggingface_hub-0.36.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/42/08535de942011b644dc4ca856082bbe7365f6244ae2b80afe55bc4f76225/turbovec-0.7.0-cp39-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
@@ -4563,6 +4614,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -4767,6 +4820,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/ed/f3b81ca8743d69b95d679b95e6e1d22cb7cc678ae77c6a57827303a7e48c/rerankers-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/f6/adbdaca6f0023a0d1887a63c332f37938644c714989af51c779fadb42b80/turbovec-0.7.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl
@@ -4799,6 +4853,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -4952,6 +5008,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/17/20c2552266728ceba271967b87919664ecc0e33efca29c3efc6baf88c5f9/ipykernel-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/55/5e0c31ccbde716859ec81a8c4dc197973c40e0519a54778b26121d5f8056/turbovec-0.7.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl
@@ -5036,6 +5093,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -5155,6 +5214,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6c/79/3912a94cf27ec503e51ba493692d6db1e3cd8ac7ac52b0b47c8e33d7f4f9/greenlet-3.3.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6e/78/a850fed8aeef96d4a99043c90b818b2ed5419cd5b24a4049fd7cfb9f1471/fakeredis-2.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/76/9a/1f8d8acfe5666871b794047ffcb7312b3d720e277c9d395dbaf7d79e3b1f/turbovec-0.7.0-cp39-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl
@@ -6134,6 +6194,31 @@ packages:
   - pkg:pypi/jinja2?source=hash-mapping
   size: 112714
   timestamp: 1741263433881
+- conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+  sha256: 1a88069ac61d2756ccaf26a6c206ab4d56610fb054bd2fffb5df4cd0744ab78e
+  md5: 75932da6f03a6bef32b70a51e991f6eb
+  depends:
+  - packaging
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/lazy-loader?source=hash-mapping
+  run_exports: {}
+  size: 14883
+  timestamp: 1772817374026
+- conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
+  sha256: 42adb08ded0662114a3146627b24d2cd5eba3bfc3ed424374bac869cdc1745a9
+  md5: 4c8327180586e7b1cd8b6815fc8827f1
+  depends:
+  - lazy-loader 0.5 pyhd8ed1ab_0
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 7565
+  timestamp: 1772817387506
 - conda: https://prefix.dev/conda-forge/noarch/numpydoc-1.9.0-pyhe01879c_1.conda
   sha256: 9e1f3dda737ac9aeec3c245c5d856d0268c4f64a5293c094298d74bb55e2b165
   md5: 66f9ba52d846feffa1c5d62522324b4f
@@ -7267,48 +7352,24 @@ packages:
 - pypi: .
   name: llamabot
   requires_dist:
-  - openai
-  - loguru
-  - python-dotenv
-  - typer>=0.15.3
-  - pyprojroot
-  - beautifulsoup4
+  - lazy-loader
   - litellm>=1.71.0,<1.82.7
-  - python-slugify
+  - loguru
   - pydantic>=2.0
-  - numpy
-  - jinja2
-  - fastapi>=0.115.9
-  - uvicorn
-  - tenacity
-  - python-multipart
+  - python-dotenv
+  - pyprojroot
+  - python-slugify
   - httpx
-  - tqdm
+  - jinja2
   - sqlalchemy
-  - pdfminer-six
+  - tenacity
+  - tqdm
+  - typer>=0.15.3
   - numpydoc
-  - chonkie
-  - starlette
-  - duckduckgo-search
-  - networkx
-  - docstring-parser>=0.17.0,<0.18
-  - fastmcp
-  - python-frontmatter
-  - pocketflow
-  - pillow
-  - ics ; extra == 'notebooks'
-  - tzlocal ; extra == 'notebooks'
-  - modal ; extra == 'notebooks'
-  - ipykernel ; extra == 'notebooks'
-  - lancedb>=0.22 ; extra == 'rag'
-  - rank-bm25 ; extra == 'rag'
-  - pylance ; extra == 'rag'
-  - sentence-transformers ; extra == 'rag'
-  - rerankers ; extra == 'rag'
-  - turbovec ; extra == 'turbovec'
-  - sentence-transformers ; extra == 'turbovec'
+  - pocketflow ; extra == 'agent'
   - docker ; extra == 'agent'
   - markdownify ; extra == 'agent'
+  - networkx ; extra == 'chat-memory'
   - nbformat ; extra == 'cli'
   - python-frontmatter ; extra == 'cli'
   - rich ; extra == 'cli'
@@ -7316,7 +7377,35 @@ packages:
   - prompt-toolkit ; extra == 'cli'
   - case-converter ; extra == 'cli'
   - pyperclip ; extra == 'cli'
-  - llamabot[notebooks,rag,agent,cli,turbovec] ; extra == 'all'
+  - pillow ; extra == 'image'
+  - fastmcp ; extra == 'mcp'
+  - beautifulsoup4 ; extra == 'rag'
+  - chonkie ; extra == 'rag'
+  - duckduckgo-search ; extra == 'rag'
+  - docstring-parser>=0.17.0,<0.18 ; extra == 'rag'
+  - lancedb>=0.22 ; extra == 'rag'
+  - numpy ; extra == 'rag'
+  - pdfminer-six ; extra == 'rag'
+  - pylance ; extra == 'rag'
+  - rank-bm25 ; extra == 'rag'
+  - rerankers ; extra == 'rag'
+  - sentence-transformers ; extra == 'rag'
+  - turbovec ; extra == 'rag'
+  - beautifulsoup4 ; extra == 'tools'
+  - docstring-parser>=0.17.0,<0.18 ; extra == 'tools'
+  - duckduckgo-search ; extra == 'tools'
+  - requests ; extra == 'tools'
+  - fastapi>=0.115.9 ; extra == 'web'
+  - python-multipart ; extra == 'web'
+  - starlette ; extra == 'web'
+  - uvicorn ; extra == 'web'
+  - ics ; extra == 'notebooks'
+  - tzlocal ; extra == 'notebooks'
+  - modal ; extra == 'notebooks'
+  - ipykernel ; extra == 'notebooks'
+  - llamabot[agent,chat-memory,cli,image,mcp,rag,tools,web,notebooks] ; extra == 'all'
+  - turbovec ; extra == 'turbovec'
+  - sentence-transformers ; extra == 'turbovec'
   requires_python: '>=3.10,<3.14'
 - pypi: https://files.pythonhosted.org/packages/00/5e/1f27d937a4983c8783d9255c4880e9b8a5a1774ebc4eb55d4c3f3d112d6b/pocketflow-0.0.3-py3-none-any.whl
   name: pocketflow
@@ -10525,6 +10614,17 @@ packages:
   version: 0.4.1
   sha256: cd547953428f7abb73c5ad82cbb32109566204260d98e41e5dfdc682eb7f8403
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/76/9a/1f8d8acfe5666871b794047ffcb7312b3d720e277c9d395dbaf7d79e3b1f/turbovec-0.7.0-cp39-abi3-win_amd64.whl
+  name: turbovec
+  version: 0.7.0
+  sha256: 79e29e1e431d897d2de482abc96a5623bba26eea71cec27db57c1c1212b26997
+  requires_dist:
+  - numpy>=1.20
+  - agno>=2.0 ; extra == 'agno'
+  - haystack-ai>=2.0 ; extra == 'haystack'
+  - langchain-core>=0.3 ; extra == 'langchain'
+  - llama-index-core>=0.11 ; extra == 'llama-index'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl
   name: opentelemetry-instrumentation
   version: 0.60b1
@@ -11980,6 +12080,17 @@ packages:
   - importlib-metadata>=7.0.2 ; python_full_version < '3.10' and extra == 'type'
   - jaraco-develop>=7.21 ; sys_platform != 'cygwin' and extra == 'type'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a4/55/5e0c31ccbde716859ec81a8c4dc197973c40e0519a54778b26121d5f8056/turbovec-0.7.0-cp39-abi3-macosx_11_0_arm64.whl
+  name: turbovec
+  version: 0.7.0
+  sha256: f57159e5d197879849bf532a14bef13ffeb6cc37fe7eec9cd5c833061c8dc03f
+  requires_dist:
+  - numpy>=1.20
+  - agno>=2.0 ; extra == 'agno'
+  - haystack-ai>=2.0 ; extra == 'haystack'
+  - langchain-core>=0.3 ; extra == 'langchain'
+  - llama-index-core>=0.11 ; extra == 'llama-index'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
   name: python-slugify
   version: 8.0.4
@@ -12942,6 +13053,17 @@ packages:
   - requests ; extra == 'telegram'
   - ipywidgets>=6 ; extra == 'notebook'
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/d1/42/08535de942011b644dc4ca856082bbe7365f6244ae2b80afe55bc4f76225/turbovec-0.7.0-cp39-abi3-manylinux_2_28_aarch64.whl
+  name: turbovec
+  version: 0.7.0
+  sha256: 99cb2a6a841b760b00e097c4bdef1b8697f0a1edaf67e91df1f488a5a353c4ba
+  requires_dist:
+  - numpy>=1.20
+  - agno>=2.0 ; extra == 'agno'
+  - haystack-ai>=2.0 ; extra == 'haystack'
+  - langchain-core>=0.3 ; extra == 'langchain'
+  - llama-index-core>=0.11 ; extra == 'llama-index'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl
   name: pywin32
   version: '311'
@@ -13160,6 +13282,17 @@ packages:
   - python-multipart>=0.0.18 ; extra == 'full'
   - pyyaml ; extra == 'full'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/d9/5d/ad86864477be969dc9f934ef2c10c515096ba69790068df77605c989709e/turbovec-0.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
+  name: turbovec
+  version: 0.7.0
+  sha256: cd30062633060f6a0f66217fc789853155927ff46b524172df0494490bca306f
+  requires_dist:
+  - numpy>=1.20
+  - agno>=2.0 ; extra == 'agno'
+  - haystack-ai>=2.0 ; extra == 'haystack'
+  - langchain-core>=0.3 ; extra == 'langchain'
+  - llama-index-core>=0.11 ; extra == 'llama-index'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/d9/75/11d0e66b3cdf998c996489581bdad8900db79ebd83513e45c19548f1cba4/grpcio-1.76.0-cp312-cp312-macosx_11_0_universal2.whl
   name: grpcio
   version: 1.76.0
@@ -13445,6 +13578,17 @@ packages:
   - black>=19.3b0 ; python_full_version >= '3.6' and extra == 'dev'
   - pytest>=4.6.2 ; extra == 'dev'
   requires_python: '>=3.5'
+- pypi: https://files.pythonhosted.org/packages/e1/f6/adbdaca6f0023a0d1887a63c332f37938644c714989af51c779fadb42b80/turbovec-0.7.0.tar.gz
+  name: turbovec
+  version: 0.7.0
+  sha256: 35a5d29a7db962dbe59c56c93e6b8a685228d2d3e3e2fdef9e126c860bb581ce
+  requires_dist:
+  - numpy>=1.20
+  - langchain-core>=0.3 ; extra == 'langchain'
+  - llama-index-core>=0.11 ; extra == 'llama-index'
+  - haystack-ai>=2.0 ; extra == 'haystack'
+  - agno>=2.0 ; extra == 'agno'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl
   name: mcp
   version: 1.25.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ ignore-private = false
 ignore-property-decorators = false
 ignore-module = false
 fail-under = 100
-exclude = ["setup.py", "docs", "build", "examples"]
+exclude = ["setup.py", "docs", "build", "examples", "scripts", "tests"]
 ignore-regex = ["^get$", "^mock_.*", ".*BaseClass.*", "^no_docstring_func$", "^empty_func$"]
 verbose = 2
 quiet = false
@@ -70,37 +70,23 @@ artifacts = [
 [project]
 name = "llamabot"
 version = "0.19.1"
-# Runtime dependencies below
+# Runtime dependencies below — only truly core deps live here.
+# Heavy/feature-specific deps are in [project.optional-dependencies].
 dependencies = [
-    "openai",
-    "loguru",
-    "python-dotenv",
-    "typer>=0.15.3",
-    "pyprojroot",
-    "beautifulsoup4",
+    "lazy_loader",
     "litellm>=1.71.0,<1.82.7", # temporary upper bound due to 2026-03-24 compromised 1.82.7/1.82.8 releases
-    "python-slugify",
+    "loguru",
     "pydantic>=2.0",
-    "numpy",
-    "jinja2",
-    "fastapi>=0.115.9",
-    "uvicorn",
-    "tenacity",
-    "python-multipart",
+    "python-dotenv",
+    "pyprojroot",
+    "python-slugify",
     "httpx",
-    "tqdm",
+    "jinja2",
     "sqlalchemy",
-    "pdfminer.six",
+    "tenacity",
+    "tqdm",
+    "typer>=0.15.3",
     "numpydoc", # Temporarily added on 2025-05-10 to fix LiteLLM's omission of this dependency.
-    "chonkie",
-    "starlette",
-    "duckduckgo-search",
-    "networkx",
-    "docstring-parser>=0.17.0,<0.18",
-    "fastmcp",
-    "python-frontmatter",
-    "pocketflow",
-    "pillow",
 ]
 requires-python = ">=3.10,<3.14"
 description = "A Pythonic interface to LLMs."
@@ -114,26 +100,24 @@ readme = "README.md"
 llamabot = "llamabot.cli:app"
 
 [project.optional-dependencies]
-notebooks = [
-    "ics",
-    "tzlocal",
-    "modal",
-    "ipykernel",
-]
-rag = [
-    "lancedb>=0.22",
-    "rank-bm25",
-    "pylance",
-    "sentence-transformers",
-    "rerankers",
-]
-turbovec = [
-    "turbovec",
-    "sentence-transformers",
-]
+# Feature-specific extras — install only what you need.
+#   pip install llamabot[agent]   — agent bots with tool orchestration
+#   pip install llamabot[rag]     — RAG pipelines (includes turbovec, lancedb)
+#   pip install llamabot[mcp]     — MCP (Model Context Protocol) integration
+#   pip install llamabot[tools]   — built-in agent tools (web search, scraping)
+#   pip install llamabot[image]   — image generation bot
+#   pip install llamabot[web]     — FastAPI web UI and log viewer
+#   pip install llamabot[chat-memory] — graph-based conversation memory
+#   pip install llamabot[cli]     — full CLI with rich output, git helpers, etc.
+#   pip install llamabot[all]     — everything
+
 agent = [
+    "pocketflow",
     "docker",
     "markdownify",
+]
+chat-memory = [
+    "networkx",
 ]
 cli = [
     "nbformat",
@@ -144,8 +128,51 @@ cli = [
     "case-converter",
     "pyperclip",
 ]
+image = [
+    "pillow",
+]
+mcp = [
+    "fastmcp",
+]
+rag = [
+    "beautifulsoup4",
+    "chonkie",
+    "duckduckgo-search",
+    "docstring-parser>=0.17.0,<0.18",
+    "lancedb>=0.22",
+    "numpy",
+    "pdfminer.six",
+    "pylance",
+    "rank-bm25",
+    "rerankers",
+    "sentence-transformers",
+    "turbovec",
+]
+tools = [
+    "beautifulsoup4",
+    "docstring-parser>=0.17.0,<0.18",
+    "duckduckgo-search",
+    "requests",
+]
+web = [
+    "fastapi>=0.115.9",
+    "python-multipart",
+    "starlette",
+    "uvicorn",
+]
+notebooks = [
+    "ics",
+    "tzlocal",
+    "modal",
+    "ipykernel",
+]
 all = [
-    "llamabot[notebooks,rag,agent,cli,turbovec]"
+    "llamabot[agent,chat-memory,cli,image,mcp,rag,tools,web,notebooks]"
+]
+# Shorthand aliases
+turbovec = [
+    "turbovec",
+    "sentence-transformers",
 ]
 
 [dependency-groups]
@@ -160,7 +187,7 @@ channels = ["https://prefix.dev/conda-forge"]
 platforms = ["osx-arm64", "linux-64", "osx-64", "linux-aarch64", "win-64"]
 
 [tool.pixi.pypi-dependencies]
-llamabot = { path = ".", editable = true, extras = ["agent", "cli", "rag", "notebooks"] }
+llamabot = { path = ".", editable = true, extras = ["agent", "cli", "rag", "notebooks", "tools", "mcp", "image", "web", "chat-memory"] }
 
 [tool.pixi.feature.tests.pypi-dependencies]
 pytest = "*"
@@ -208,6 +235,7 @@ bare = ["devtools"]
 python-multipart = "*"
 numpydoc = ">=1.8.0,<2"
 python-frontmatter = ">=1.1.0,<2"
+lazy_loader = "*"
 
 [tool.ty.environment]
 python = "./.pixi/envs/default"

--- a/scripts/benchmark_imports.py
+++ b/scripts/benchmark_imports.py
@@ -6,10 +6,13 @@
 
 Run with: pixi run python scripts/benchmark_imports.py
 
+With --ci: output JSON to benchmark-results.json for CI reporting.
+
 Each benchmark is run in a subprocess to get a clean import
 (no cached modules from previous benchmarks).
 """
 
+import json
 import subprocess
 import sys
 import textwrap
@@ -39,38 +42,48 @@ def bench(label: str, code: str) -> float:
     return elapsed
 
 
+BENCHMARKS = [
+    ("import llamabot", "import llamabot"),
+    ("from llamabot import SimpleBot", "from llamabot import SimpleBot"),
+    ("from llamabot import AgentBot", "from llamabot import AgentBot"),
+    ("from llamabot import ToolBot", "from llamabot import ToolBot"),
+    ("from llamabot import tool", "from llamabot import tool"),
+    ("from llamabot import prompt", "from llamabot import prompt"),
+    ("from llamabot import user, system", "from llamabot import user, system"),
+    ("from llamabot import span", "from llamabot import span"),
+    ("from llamabot import ChatMemory", "from llamabot import ChatMemory"),
+    ("from llamabot import Experiment", "from llamabot import Experiment"),
+    ("from llamabot import QueryBot", "from llamabot import QueryBot"),
+    ("from llamabot import ImageBot", "from llamabot import ImageBot"),
+    ("from llamabot import StructuredBot", "from llamabot import StructuredBot"),
+    ("from llamabot.recorder import span", "from llamabot.recorder import span"),
+    (
+        "full (import everything)",
+        "import llamabot; [getattr(llamabot, n) for n in llamabot.__all__]",
+    ),
+]
+
+
 def main():
-    benchmarks = [
-        ("import llamabot", "import llamabot"),
-        ("from llamabot import SimpleBot", "from llamabot import SimpleBot"),
-        ("from llamabot import AgentBot", "from llamabot import AgentBot"),
-        ("from llamabot import ToolBot", "from llamabot import ToolBot"),
-        ("from llamabot import tool", "from llamabot import tool"),
-        ("from llamabot import prompt", "from llamabot import prompt"),
-        ("from llamabot import user, system", "from llamabot import user, system"),
-        ("from llamabot import span", "from llamabot import span"),
-        ("from llamabot import ChatMemory", "from llamabot import ChatMemory"),
-        ("from llamabot import Experiment", "from llamabot import Experiment"),
-        ("from llamabot import QueryBot", "from llamabot import QueryBot"),
-        ("from llamabot import ImageBot", "from llamabot import ImageBot"),
-        ("from llamabot import StructuredBot", "from llamabot import StructuredBot"),
-        ("from llamabot.recorder import span", "from llamabot.recorder import span"),
-        (
-            "full (import everything)",
-            "import llamabot; [getattr(llamabot, n) for n in llamabot.__all__]",
-        ),
-    ]
+    ci_mode = "--ci" in sys.argv
+    results = []
 
     print("=== llamabot Import Benchmarks ===")
     print(f"{'Import':50s} {'Time':>8s}")
     print("-" * 60)
-    for label, code in benchmarks:
+    for label, code in BENCHMARKS:
         elapsed = bench(label, code)
         if elapsed >= 0:
             print(f"  {label:48s} {elapsed:>6.3f}s")
+            results.append({"label": label, "time_s": round(elapsed, 3)})
 
     print()
     print("All benchmarks use fresh subprocesses (no module caching).")
+
+    if ci_mode:
+        with open("benchmark-results.json", "w") as f:
+            json.dump(results, f, indent=2)
+        print("\nResults written to benchmark-results.json")
 
 
 if __name__ == "__main__":

--- a/scripts/benchmark_imports.py
+++ b/scripts/benchmark_imports.py
@@ -1,0 +1,77 @@
+# /// script
+# dependencies = ["lazy_loader"]
+# ///
+
+"""Benchmark llamabot import times for different usage patterns.
+
+Run with: pixi run python scripts/benchmark_imports.py
+
+Each benchmark is run in a subprocess to get a clean import
+(no cached modules from previous benchmarks).
+"""
+
+import subprocess
+import sys
+import textwrap
+
+
+def bench(label: str, code: str) -> float:
+    """Run *code* in a fresh subprocess and return the elapsed time."""
+    script = textwrap.dedent(
+        f"""\
+        import time
+        t = time.perf_counter()
+        {code}
+        elapsed = time.perf_counter() - t
+        print(f"{{elapsed:.3f}}")
+    """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"  {label:50s} FAILED")
+        print(f"    stderr: {result.stderr.strip()}")
+        return -1.0
+    elapsed = float(result.stdout.strip().splitlines()[-1])
+    return elapsed
+
+
+def main():
+    benchmarks = [
+        ("import llamabot", "import llamabot"),
+        ("from llamabot import SimpleBot", "from llamabot import SimpleBot"),
+        ("from llamabot import AgentBot", "from llamabot import AgentBot"),
+        ("from llamabot import ToolBot", "from llamabot import ToolBot"),
+        ("from llamabot import tool", "from llamabot import tool"),
+        ("from llamabot import prompt", "from llamabot import prompt"),
+        ("from llamabot import user, system", "from llamabot import user, system"),
+        ("from llamabot import span", "from llamabot import span"),
+        ("from llamabot import ChatMemory", "from llamabot import ChatMemory"),
+        ("from llamabot import Experiment", "from llamabot import Experiment"),
+        ("from llamabot import QueryBot", "from llamabot import QueryBot"),
+        ("from llamabot import ImageBot", "from llamabot import ImageBot"),
+        ("from llamabot import StructuredBot", "from llamabot import StructuredBot"),
+        ("from llamabot.recorder import span", "from llamabot.recorder import span"),
+        (
+            "full (import everything)",
+            "import llamabot; [getattr(llamabot, n) for n in llamabot.__all__]",
+        ),
+    ]
+
+    print("=== llamabot Import Benchmarks ===")
+    print(f"{'Import':50s} {'Time':>8s}")
+    print("-" * 60)
+    for label, code in benchmarks:
+        elapsed = bench(label, code)
+        if elapsed >= 0:
+            print(f"  {label:48s} {elapsed:>6.3f}s")
+
+    print()
+    print("All benchmarks use fresh subprocesses (no module caching).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/precache_embeddings.py
+++ b/scripts/precache_embeddings.py
@@ -1,0 +1,25 @@
+"""Pre-cache llamabot's default embedding model.
+
+Downloading ``minishlab/potion-base-8M`` (~60 MB) at *install* time avoids
+the first-run latency penalty — especially important inside Docker containers
+where every cold start would otherwise hit the network.
+
+Usage::
+
+    # standalone script
+    pixi run python scripts/precache_embeddings.py
+
+    # via CLI (after installation)
+    llamabot precache
+
+    # in a Dockerfile
+    RUN pip install llamabot[rag] && python -c "from llamabot.precache import precache_embedding_model; precache_embedding_model()"
+"""
+
+import sys
+
+from llamabot.precache import DEFAULT_MODEL, precache_embedding_model
+
+if __name__ == "__main__":
+    model = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_MODEL
+    precache_embedding_model(model)

--- a/tests/bot/test_agentbot.py
+++ b/tests/bot/test_agentbot.py
@@ -265,29 +265,22 @@ def test_agentbot_default_decide_node():
     assert bot.decide_node.tools == bot.tools
 
 
-@patch("llamabot.bot.agentbot.Flow")
-def test_agentbot_call_execution(mock_flow_class):
+def test_agentbot_call_execution():
     """Test __call__ method execution."""
-    # Mock the flow
     mock_flow = MagicMock()
 
-    # flow.run() modifies shared state in place, so we need to set up the shared dict
     def mock_run(shared):
         shared["result"] = "test result"
 
     mock_flow.run.side_effect = mock_run
-    mock_flow_class.return_value = mock_flow
 
     bot = AgentBot(tools=[echo_function])
-
-    # Mock the flow attribute since it's created in __init__
     bot.flow = mock_flow
 
     result = bot("test query")
 
     assert result == "test result"
     assert mock_flow.run.called
-    # Check that shared state was set up correctly
     call_args = mock_flow.run.call_args[0][0]
     assert "memory" in call_args
     assert call_args["memory"] == ["test query"]
@@ -295,22 +288,16 @@ def test_agentbot_call_execution(mock_flow_class):
     assert call_args["globals_dict"] == {}
 
 
-@patch("llamabot.bot.agentbot.Flow")
-def test_agentbot_call_with_globals_dict(mock_flow_class):
+def test_agentbot_call_with_globals_dict():
     """Test __call__ method with globals_dict parameter."""
-    # Mock the flow
     mock_flow = MagicMock()
 
-    # flow.run() modifies shared state in place, so we need to set up the shared dict
     def mock_run(shared):
         shared["result"] = "test result"
 
     mock_flow.run.side_effect = mock_run
-    mock_flow_class.return_value = mock_flow
 
     bot = AgentBot(tools=[echo_function])
-
-    # Mock the flow attribute since it's created in __init__
     bot.flow = mock_flow
 
     test_globals = {"my_var": "test_value", "my_number": 42}
@@ -318,7 +305,6 @@ def test_agentbot_call_with_globals_dict(mock_flow_class):
 
     assert result == "test result"
     assert mock_flow.run.called
-    # Check that shared state includes globals_dict
     call_args = mock_flow.run.call_args[0][0]
     assert "memory" in call_args
     assert call_args["memory"] == ["test query"]

--- a/tests/bot/test_simplebot.py
+++ b/tests/bot/test_simplebot.py
@@ -152,7 +152,7 @@ def test_simple_bot_init_invalid_stream_target():
 @patch("llamabot.bot.simplebot.stream_chunks")
 @patch("llamabot.bot.simplebot.extract_tool_calls")
 @patch("llamabot.bot.simplebot.extract_content")
-@patch("llamabot.bot.simplebot.sqlite_log")
+@patch("llamabot.recorder.sqlite_log")
 @given(
     system_prompt=st.text(min_size=1),
     human_message=st.text(min_size=1),
@@ -212,7 +212,7 @@ def test_simple_bot_call(
 @patch("llamabot.bot.simplebot.stream_chunks")
 @patch("llamabot.bot.simplebot.extract_tool_calls")
 @patch("llamabot.bot.simplebot.extract_content")
-@patch("llamabot.bot.simplebot.sqlite_log")
+@patch("llamabot.recorder.sqlite_log")
 def test_simple_bot_call_with_chat_memory(
     mock_sqlite_log,
     mock_extract_content,
@@ -436,8 +436,7 @@ def test_stream_chunks_with_model_response():
 
 
 @patch("builtins.print")
-# Patch stream_chunk_builder to prevent sorting errors with mock objects
-@patch("llamabot.bot.simplebot.stream_chunk_builder")
+@patch("litellm.stream_chunk_builder")
 def test_stream_chunks_stdout(mock_stream_chunk_builder, mock_print):
     """Test the stream_chunks function with stdout target."""
     # Create mock generator
@@ -459,7 +458,7 @@ def test_stream_chunks_stdout(mock_stream_chunk_builder, mock_print):
     mock_print.assert_has_calls([call("Hello", end=""), call(" world", end="")])
 
 
-@patch("llamabot.bot.simplebot.stream_chunk_builder")
+@patch("litellm.stream_chunk_builder")
 def test_stream_chunks_panel(mock_stream_chunk_builder):
     """Test the stream_chunks function with panel target."""
     # Create mock generator
@@ -487,7 +486,7 @@ def test_stream_chunks_panel(mock_stream_chunk_builder):
     assert result_list == ["Hello", "Hello world"]
 
 
-@patch("llamabot.bot.simplebot.stream_chunk_builder")
+@patch("litellm.stream_chunk_builder")
 def test_stream_chunks_api(mock_stream_chunk_builder):
     """Test the stream_chunks function with api target."""
     # Create mock generator

--- a/tests/test_import_smoke.py
+++ b/tests/test_import_smoke.py
@@ -1,0 +1,171 @@
+"""Smoke tests for lazy import behaviour.
+
+These tests verify that:
+1. ``import llamabot`` is fast (< 0.5 s)
+2. All public symbols remain accessible
+3. No import-time crashes occur for optional extras
+"""
+
+import time
+
+
+MAX_BARE_IMPORT = 0.5
+MAX_SIMPLEBOT_IMPORT = 1.0
+
+
+def test_bare_import_fast():
+    """import llamabot should complete in under 0.5 s."""
+    start = time.perf_counter()
+
+    elapsed = time.perf_counter() - start
+    assert (
+        elapsed < MAX_BARE_IMPORT
+    ), f"import llamabot took {elapsed:.3f}s (> {MAX_BARE_IMPORT}s)"
+
+
+def test_simplebot_accessible():
+    from llamabot import SimpleBot
+
+    assert SimpleBot is not None
+
+
+def test_async_simplebot_accessible():
+    from llamabot import AsyncSimpleBot
+
+    assert AsyncSimpleBot is not None
+
+
+def test_structuredbot_accessible():
+    from llamabot import StructuredBot
+
+    assert StructuredBot is not None
+
+
+def test_async_structuredbot_accessible():
+    from llamabot import AsyncStructuredBot
+
+    assert AsyncStructuredBot is not None
+
+
+def test_agentbot_accessible():
+    from llamabot import AgentBot
+
+    assert AgentBot is not None
+
+
+def test_async_agentbot_accessible():
+    from llamabot import AsyncAgentBot
+
+    assert AsyncAgentBot is not None
+
+
+def test_toolbot_accessible():
+    from llamabot import ToolBot
+
+    assert ToolBot is not None
+
+
+def test_async_toolbot_accessible():
+    from llamabot import AsyncToolBot
+
+    assert AsyncToolBot is not None
+
+
+def test_querybot_accessible():
+    from llamabot import QueryBot
+
+    assert QueryBot is not None
+
+
+def test_async_querybot_accessible():
+    from llamabot import AsyncQueryBot
+
+    assert AsyncQueryBot is not None
+
+
+def test_imagebot_accessible():
+    from llamabot import ImageBot
+
+    assert ImageBot is not None
+
+
+def test_tool_decorator_accessible():
+    from llamabot import tool
+
+    assert callable(tool)
+
+
+def test_prompt_decorator_accessible():
+    from llamabot import prompt
+
+    assert callable(prompt)
+
+
+def test_message_helpers():
+    from llamabot import dev, system, user
+
+    assert callable(user)
+    assert callable(system)
+    assert callable(dev)
+
+
+def test_chat_memory_accessible():
+    from llamabot import ChatMemory
+
+    assert ChatMemory is not None
+
+
+def test_nodeify_accessible():
+    from llamabot import nodeify
+
+    assert callable(nodeify)
+
+
+def test_recorder_symbols():
+    from llamabot import (
+        span,
+    )
+
+    assert callable(span)
+
+
+def test_experiment_symbols():
+    from llamabot import Experiment, metric
+
+    assert Experiment is not None
+    assert callable(metric)
+
+
+def test_docstore_symbols():
+    from llamabot import BM25DocStore, LanceDBDocStore, TurboVecDocStore
+
+    assert BM25DocStore is not None
+    assert LanceDBDocStore is not None
+    assert TurboVecDocStore is not None
+
+
+def test_set_debug_mode():
+    from llamabot import set_debug_mode
+
+    assert callable(set_debug_mode)
+
+
+def test_all_exports_importable():
+    """Every name in __all__ should be importable without error."""
+    import llamabot
+
+    for name in llamabot.__all__:
+        assert hasattr(llamabot, name), f"{name} in __all__ but not accessible"
+
+
+def test_simplebot_creation():
+    """SimpleBot can be instantiated with basic args."""
+    from llamabot import SimpleBot
+
+    bot = SimpleBot(
+        system_prompt="You are a test bot.",
+        mock_response="hello",
+        model_name="gpt-4o-mini",
+    )
+    assert bot.model_name == "gpt-4o-mini"
+    assert bot.temperature == 0.0


### PR DESCRIPTION
## Summary

- **Lazy imports via `lazy_loader`**: `import llamabot` drops from ~1.1s to ~0.04s (25x faster). Individual symbols load on-demand.
- **Restructured optional deps**: Granular extras (`[mcp]`, `[agent]`, `[tools]`, `[image]`, `[web]`, `[chat-memory]`, `[rag]`, `[cli]`). `pip install llamabot` is now lighter; install only what you need.
- **Pre-cache command**: `llamabot precache` pre-downloads the `minishlab/potion-base-8M` embedding model (~60 MB) at build time, avoiding first-run latency in Docker containers.

## Import time benchmarks (subprocess-isolated)

| Import | Before | After |
|---|---|---|
| `import llamabot` | ~1.1s | ~0.04s |
| `from llamabot import SimpleBot` | ~1.1s | ~0.17s |
| `from llamabot import AgentBot` | ~1.1s | ~0.04s |
| `from llamabot import user, system` | ~1.1s | ~0.13s |
| `from llamabot import prompt` | ~1.1s | ~0.22s |
| full (import everything) | ~1.1s | ~1.1s |

## Changes

### `llamabot/__init__.py`
- Replaced all eager imports with `lazy_loader.attach()` for deferred loading
- Logger config and `~/.llamabot` mkdir kept at module level (fast, <1ms)

### `llamabot/bot/simplebot.py`
- Deferred `litellm` and `recorder` (sqlalchemy) imports into function bodies
- Added `TYPE_CHECKING` imports for type annotations

### `llamabot/bot/agentbot.py`
- Deferred `pocketflow`, `components.tools`, `mcp.manager` into `__init__`

### `llamabot/components/tools.py`
- Deferred `bs4`, `duckduckgo_search`, `docstring_parser`, `SimpleBot`, `requests`, `recorder`, `pocketflow`, `sandbox` into function bodies

### `llamabot/components/chat_memory/`
- Deferred `networkx`, `StructuredBot`, `prompt` into function bodies across `memory.py`, `selectors.py`, `storage.py`, `retrieval.py`, `visualization.py`

### `llamabot/mcp/session.py`
- Deferred `fastmcp` imports into function bodies

### `pyproject.toml`
- Added `lazy_loader` to core deps
- Restructured optional deps into: `[mcp]`, `[agent]`, `[tools]`, `[image]`, `[web]`, `[chat-memory]`, `[rag]`, `[cli]`, `[notebooks]`, `[turbovec]`, `[all]`

### New files
- `llamabot/precache.py` — importable `precache_embedding_model()` function
- `scripts/precache_embeddings.py` — standalone pre-cache script
- `scripts/benchmark_imports.py` — subprocess-isolated import benchmarks
- `tests/test_import_smoke.py` — 23 tests verifying all symbols accessible

## Dockerfile usage

```dockerfile
RUN pip install llamabot[rag] && \
    python -c "from llamabot.precache import precache_embedding_model; precache_embedding_model()"
```
