### PR TITLE
fix: lazy-import docstore/numpy to avoid core dependency on numpy

### DIFF
--- a/llamabot/bot/simplebot.py
+++ b/llamabot/bot/simplebot.py
@@ -19,7 +19,6 @@ from typing import (
 from loguru import logger
 from pydantic import BaseModel
 
-from llamabot.components.docstore import AbstractDocumentStore
 from llamabot.components.messages import (
     AIMessage,
     BaseMessage,
@@ -32,6 +31,7 @@ from llamabot.config import default_language_model
 if TYPE_CHECKING:
     from litellm import CustomStreamWrapper, ModelResponse
 
+    from llamabot.components.docstore import AbstractDocumentStore
     from llamabot.recorder import Span, SpanList
 
 prompt_recorder_var = contextvars.ContextVar("prompt_recorder")

--- a/llamabot/components/docstore.py
+++ b/llamabot/components/docstore.py
@@ -10,11 +10,16 @@ LanceDB is a great default choice because of its simplicity and FOSS nature.
 Hence we use it by default.
 """
 
+from __future__ import annotations
+
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import numpy as np
 import slugify
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class AbstractDocumentStore:
@@ -710,6 +715,8 @@ class TurboVecDocStore(AbstractDocumentStore):
         :param texts: Texts to embed.
         :return: Float32 numpy array of shape (len(texts), dim).
         """
+        import numpy as np
+
         vectors = self.embedder.encode(
             texts, convert_to_numpy=True, show_progress_bar=False
         )
@@ -732,6 +739,8 @@ class TurboVecDocStore(AbstractDocumentStore):
             return
 
         vector = self._embed([document])
+        import numpy as np
+
         doc_id = np.array([self.next_id], dtype=np.uint64)
         self.index.add_with_ids(vector, doc_id)
         self.id_to_doc[self.next_id] = document
@@ -749,6 +758,8 @@ class TurboVecDocStore(AbstractDocumentStore):
             return
 
         vectors = self._embed(new_docs)
+        import numpy as np
+
         ids = np.array(
             list(range(self.next_id, self.next_id + len(new_docs))), dtype=np.uint64
         )


### PR DESCRIPTION
Closes #372

## Problem

`simplebot.py` unconditionally imports `AbstractDocumentStore` from `llamabot.components.docstore`, which does `import numpy as np` at module level. Since `numpy` is only in the `[rag]` extras, core installs fail with:

```
ModuleNotFoundError: No module named 'numpy'
```

## Fix

Two changes to break the import chain:

1. **`simplebot.py``**: Moved `from llamabot.components.docstore import AbstractDocumentStore` under the `TYPE_CHECKING` guard. The import is only used as a type annotation for the `memory` parameter, and `from __future__ import annotations` was already present, so this is safe.

2. **`docstore.py``**: Moved `import numpy as np` from module level to local imports inside the `TurboVecDocStore` methods that actually use it (`_embed`, `append`, `extend`). Added `from __future__ import annotations` and a `TYPE_CHECKING` guard for the `np.ndarray` type hint.

## Verification

- `SimpleBot` import no longer triggers numpy import
- `AbstractDocumentStore` and `BM25DocStore` importable without numpy
- All 23 import smoke tests pass
- All 43 simplebot tests pass