### PR TITLE
fix: auto-route model text to respond_to_user when no tool call is returned

### DIFF
--- a/llamabot/bot/toolbot.py
+++ b/llamabot/bot/toolbot.py
@@ -229,6 +229,19 @@ class ToolBot(SimpleBot):
 
         tool_calls = extract_tool_calls(response)
 
+        # Capture content for auto-route fallback (coding-agent termination):
+        # when the model returns text without a tool call, DecideNode uses
+        # this to auto-route to respond_to_user instead of crashing.
+        try:
+            if hasattr(response, "choices") and response.choices:
+                self._last_content = getattr(
+                    response.choices[0].message, "content", None
+                )
+            else:
+                self._last_content = None
+        except (TypeError, AttributeError):
+            self._last_content = None
+
         # Log if we parsed tool calls from JSON content (for debugging)
         try:
             if (
@@ -319,6 +332,15 @@ class AsyncToolBot(ToolBot):
             pass
 
         tool_calls = extract_tool_calls(final)
+
+        # Capture content for auto-route fallback (coding-agent termination).
+        try:
+            if hasattr(final, "choices") and final.choices:
+                self._last_content = getattr(final.choices[0].message, "content", None)
+            else:
+                self._last_content = None
+        except (TypeError, AttributeError):
+            self._last_content = None
 
         try:
             if (

--- a/llamabot/components/pocketflow/nodes.py
+++ b/llamabot/components/pocketflow/nodes.py
@@ -496,23 +496,26 @@ class DecideNode(Node):
 
             # Handle case where no tool calls are returned
             if not tool_calls:
-                error_msg = (
-                    f"No tool calls returned from ToolBot. Model: {self.model_name}. "
+                content = getattr(bot, "_last_content", None)
+                if content:
+                    # Coding-agent termination: the model returned text
+                    # without a tool call. This is the model's final answer —
+                    # auto-route to respond_to_user instead of crashing.
+                    logger.info(
+                        "Model returned text without a tool call; "
+                        "auto-routing to respond_to_user."
+                    )
+                    if span_obj:
+                        span_obj["auto_terminated"] = True
+                        span_obj.log(
+                            "auto_terminated",
+                            reason="model_returned_text_without_tool_call",
+                        )
+                    prep_res["func_call"] = {"response": content}
+                    return "respond_to_user"
+                raise ValueError(
+                    f"No tool calls and no content from model: {self.model_name}."
                 )
-                if self.model_name.startswith("ollama") or self.model_name.startswith(
-                    "ollama_chat"
-                ):
-                    error_msg += (
-                        "Ollama models don't support tool_choice='required', so tool calls are optional. "
-                        "Ensure your system prompt explicitly requires tool calls and that the model "
-                        "supports function calling."
-                    )
-                else:
-                    error_msg += (
-                        "This may indicate the model doesn't support tool_choice='required'. "
-                        "Check the system prompt and ensure it explicitly requires tool calls."
-                    )
-                raise ValueError(error_msg)
 
             normalized_tool_calls = [
                 {
@@ -647,23 +650,23 @@ class DecideNode(Node):
             )
 
             if not tool_calls:
-                error_msg = (
-                    f"No tool calls returned from the model. Model: {self.model_name}. "
+                content = getattr(bot, "_last_content", None)
+                if content:
+                    logger.info(
+                        "Model returned text without a tool call; "
+                        "auto-routing to respond_to_user."
+                    )
+                    if span_obj:
+                        span_obj["auto_terminated"] = True
+                        span_obj.log(
+                            "auto_terminated",
+                            reason="model_returned_text_without_tool_call",
+                        )
+                    prep_res["func_call"] = {"response": content}
+                    return "respond_to_user"
+                raise ValueError(
+                    f"No tool calls and no content from model: {self.model_name}."
                 )
-                if self.model_name.startswith("ollama") or self.model_name.startswith(
-                    "ollama_chat"
-                ):
-                    error_msg += (
-                        "Ollama models don't support tool_choice='required', so tool calls are optional. "
-                        "Ensure your system prompt explicitly requires tool calls and that the model "
-                        "supports function calling."
-                    )
-                else:
-                    error_msg += (
-                        "This may indicate the model doesn't support tool_choice='required'. "
-                        "Check the system prompt and ensure it explicitly requires tool calls."
-                    )
-                raise ValueError(error_msg)
 
             normalized_tool_calls = [
                 {

--- a/tests/bot/test_agentbot.py
+++ b/tests/bot/test_agentbot.py
@@ -877,3 +877,46 @@ def test_agentbot_spans_property_has_unified_interface():
     # Verify SpanList is iterable
     assert hasattr(spans, "__iter__")
     assert hasattr(spans, "__len__")
+
+
+def test_decide_node_auto_routes_text_to_respond_to_user():
+    """When the model returns text without a tool call, DecideNode auto-routes to respond_to_user.
+
+    This is the coding-agent pattern: text without a tool call IS the final answer.
+    """
+    from llamabot.components.pocketflow.nodes import DecideNode
+
+    with patch("llamabot.bot.toolbot.ToolBot") as mock_toolbot_class:
+        mock_toolbot = MagicMock()
+        mock_toolbot.return_value = []  # no tool calls
+        mock_toolbot._last_content = "Here is the answer."
+        mock_toolbot_class.return_value = mock_toolbot
+
+        decide_node = DecideNode(
+            tools=[], system_prompt="Pick tools.", model_name="gpt-4.1"
+        )
+        prep_res = {"memory": ["test query"], "globals_dict": {}}
+
+        selected = decide_node.exec(prep_res)
+
+        assert selected == "respond_to_user"
+        assert prep_res["func_call"] == {"response": "Here is the answer."}
+
+
+def test_decide_node_raises_when_no_tool_calls_and_no_content():
+    """When the model returns neither tool calls nor content, ValueError is raised."""
+    from llamabot.components.pocketflow.nodes import DecideNode
+
+    with patch("llamabot.bot.toolbot.ToolBot") as mock_toolbot_class:
+        mock_toolbot = MagicMock()
+        mock_toolbot.return_value = []
+        mock_toolbot._last_content = None
+        mock_toolbot_class.return_value = mock_toolbot
+
+        decide_node = DecideNode(
+            tools=[], system_prompt="Pick tools.", model_name="gpt-4.1"
+        )
+        prep_res = {"memory": ["test query"], "globals_dict": {}}
+
+        with pytest.raises(ValueError, match="No tool calls and no content"):
+            decide_node.exec(prep_res)


### PR DESCRIPTION
## Problem

When a model (e.g. `gemma4:12b` via Ollama's OpenAI-compatible endpoint) returns text content without a tool call, `DecideNode._exec_decision` raised `ValueError`, crashing the agent loop. This happens because many models — especially smaller ones served via Ollama — don't reliably call the `respond_to_user` termination tool; instead they generate a plain-text answer directly.

This is the **coding-agent termination pattern**: when the model stops calling tools and returns text, that text IS the final answer. Claude Code, opencode, and every production agent framework works this way.

## Fix

Two surgical changes:

1. **`ToolBot.__call__` / `AsyncToolBot.__call__`**: capture `self._last_content` from the model response (the text the model generated).

2. **`DecideNode._exec_decision` (sync + async)**: when `not tool_calls` AND content exists, auto-route to `respond_to_user` with that content instead of raising `ValueError`. The PocketFlow graph is unchanged — the text still flows through the existing `respond_to_user` terminal node, so `shared["result"]` and the return path are preserved.

`ValueError` is still raised when **neither** tool calls **nor** content are present (truly broken model response).

## Testing

- **Unit tests**: 2 new tests in `tests/bot/test_agentbot.py` — auto-route on text, ValueError on empty response. All 34 existing tests still pass.
- **Reliability**: 10/10 (100%) success across 10 different queries with `gemma4:12b` via Ollama. Without the fix, the agent crashed 100% of the time on iteration 2.

## Backwards compatibility

Strictly more permissive: code that previously crashed now succeeds. The only breaking change is for code that catches `ValueError` from the no-tool-calls case — that path now succeeds instead of raising.