### PR TITLE
feat: instrument all AgentBot spans + waterfall chart view

### DIFF
--- a/llamabot/bot/simplebot.py
+++ b/llamabot/bot/simplebot.py
@@ -431,7 +431,20 @@ def make_response(
     """
     from litellm import completion
 
-    return completion(**completion_kwargs_for_messages(bot, messages, stream))
+    from llamabot.recorder import Span, get_current_span
+
+    current_span = get_current_span()
+    model_name = getattr(bot, "model_name", "unknown")
+    if current_span:
+        llm_span = current_span.span("llm_request", model=model_name)
+    else:
+        llm_span = Span("llm_request", model=model_name)
+
+    with llm_span:
+        kwargs = completion_kwargs_for_messages(bot, messages, stream)
+        llm_span["num_messages"] = len(messages)
+        llm_span["stream"] = stream
+        return completion(**kwargs)
 
 
 async def make_async_response(
@@ -446,7 +459,20 @@ async def make_async_response(
     """
     from litellm import acompletion
 
-    return await acompletion(**completion_kwargs_for_messages(bot, messages, stream))
+    from llamabot.recorder import Span, get_current_span
+
+    current_span = get_current_span()
+    model_name = getattr(bot, "model_name", "unknown")
+    if current_span:
+        llm_span = current_span.span("llm_request", model=model_name)
+    else:
+        llm_span = Span("llm_request", model=model_name)
+
+    with llm_span:
+        kwargs = completion_kwargs_for_messages(bot, messages, stream)
+        llm_span["num_messages"] = len(messages)
+        llm_span["stream"] = stream
+        return await acompletion(**kwargs)
 
 
 async def stream_tokens_for_messages(

--- a/llamabot/bot/toolbot.py
+++ b/llamabot/bot/toolbot.py
@@ -202,71 +202,85 @@ class ToolBot(SimpleBot):
         :param execution_history: Optional list of previously executed tool calls for context
         :return: List of tool calls to execute
         """
-        message_list, user_messages = self.compose_tool_messages(
-            *messages, execution_history=execution_history
-        )
+        from llamabot.recorder import Span, get_current_span
 
-        # Execute the plan
-        stream = self.stream_target != "none"
-        logger.debug("Message list: {}", message_list)
-        response = make_response(self, message_list, stream=stream)
-        response = stream_chunks(response, target=self.stream_target)
-        logger.debug("Response: {}", response)
+        current_span = get_current_span()
+        if current_span:
+            llm_span = current_span.span("toolbot_llm_call", model=self.model_name)
+        else:
+            llm_span = Span("toolbot_llm_call", model=self.model_name)
 
-        # Log detailed response structure for debugging tool call issues
-        try:
-            if hasattr(response, "choices") and hasattr(response.choices, "__len__"):
-                choices_len = len(response.choices)
-                if choices_len > 0:
-                    message = response.choices[0].message
-                    tool_calls_attr = getattr(message, "tool_calls", None)
-                    content_attr = getattr(message, "content", None)
-                    logger.debug("Response message.tool_calls: {}", tool_calls_attr)
-                    logger.debug("Response message.content: {}", content_attr)
-        except (TypeError, AttributeError):
-            # Skip logging if response doesn't support len() (e.g., Mock objects in tests)
-            pass
+        with llm_span:
+            message_list, user_messages = self.compose_tool_messages(
+                *messages, execution_history=execution_history
+            )
 
-        tool_calls = extract_tool_calls(response)
+            # Execute the plan
+            stream = self.stream_target != "none"
+            logger.debug("Message list: {}", message_list)
+            response = make_response(self, message_list, stream=stream)
+            response = stream_chunks(response, target=self.stream_target)
+            logger.debug("Response: {}", response)
 
-        # Capture content for auto-route fallback (coding-agent termination):
-        # when the model returns text without a tool call, DecideNode uses
-        # this to auto-route to respond_to_user instead of crashing.
-        try:
-            if hasattr(response, "choices") and response.choices:
-                self._last_content = getattr(
-                    response.choices[0].message, "content", None
-                )
-            else:
+            # Log detailed response structure for debugging tool call issues
+            try:
+                if hasattr(response, "choices") and hasattr(
+                    response.choices, "__len__"
+                ):
+                    choices_len = len(response.choices)
+                    if choices_len > 0:
+                        message = response.choices[0].message
+                        tool_calls_attr = getattr(message, "tool_calls", None)
+                        content_attr = getattr(message, "content", None)
+                        logger.debug("Response message.tool_calls: {}", tool_calls_attr)
+                        logger.debug("Response message.content: {}", content_attr)
+            except (TypeError, AttributeError):
+                # Skip logging if response doesn't support len() (e.g., Mock objects in tests)
+                pass
+
+            tool_calls = extract_tool_calls(response)
+
+            # Capture content for auto-route fallback (coding-agent termination):
+            # when the model returns text without a tool call, DecideNode uses
+            # this to auto-route to respond_to_user instead of crashing.
+            try:
+                if hasattr(response, "choices") and response.choices:
+                    self._last_content = getattr(
+                        response.choices[0].message, "content", None
+                    )
+                else:
+                    self._last_content = None
+            except (TypeError, AttributeError):
                 self._last_content = None
-        except (TypeError, AttributeError):
-            self._last_content = None
 
-        # Log if we parsed tool calls from JSON content (for debugging)
-        try:
-            if (
-                tool_calls
-                and hasattr(response, "choices")
-                and hasattr(response.choices, "__len__")
-            ):
-                choices_len = len(response.choices)
-                if choices_len > 0:
-                    message = response.choices[0].message
-                    if message.tool_calls is None and message.content:
-                        logger.debug(
-                            "Parsed tool calls from JSON content for model {}: {}",
-                            self.model_name,
-                            [tc.function.name for tc in tool_calls],
-                        )
-        except (TypeError, AttributeError):
-            # Skip logging if response doesn't support len() (e.g., Mock objects in tests)
-            pass
+            # Log if we parsed tool calls from JSON content (for debugging)
+            try:
+                if (
+                    tool_calls
+                    and hasattr(response, "choices")
+                    and hasattr(response.choices, "__len__")
+                ):
+                    choices_len = len(response.choices)
+                    if choices_len > 0:
+                        message = response.choices[0].message
+                        if message.tool_calls is None and message.content:
+                            logger.debug(
+                                "Parsed tool calls from JSON content for model {}: {}",
+                                self.model_name,
+                                [tc.function.name for tc in tool_calls],
+                            )
+            except (TypeError, AttributeError):
+                # Skip logging if response doesn't support len() (e.g., Mock objects in tests)
+                pass
 
-        if user_messages:
-            self.chat_memory.append(user_messages[0])
-            self.chat_memory.append(AIMessage(content=str(tool_calls)))
+            if user_messages:
+                self.chat_memory.append(user_messages[0])
+                self.chat_memory.append(AIMessage(content=str(tool_calls)))
 
-        return tool_calls
+            llm_span["chosen_tools"] = str(
+                [tc.function.name for tc in tool_calls] if tool_calls else []
+            )
+            return tool_calls
 
 
 class AsyncToolBot(ToolBot):
@@ -309,59 +323,73 @@ class AsyncToolBot(ToolBot):
         execution_history: Optional[List[Dict]] = None,
     ) -> list:
         """Async tool selection via ``acompletion`` (same contract as :meth:`ToolBot.__call__`)."""
-        message_list, user_messages = self.compose_tool_messages(
-            *messages, execution_history=execution_history
-        )
+        from llamabot.recorder import Span, get_current_span
 
-        stream = self.stream_target != "none"
-        logger.debug("Message list: {}", message_list)
-        response = await make_async_response(self, message_list, stream=stream)
-        final = await async_stream_chunks(self, response, target=self.stream_target)
-        logger.debug("Response: {}", final)
+        current_span = get_current_span()
+        if current_span:
+            llm_span = current_span.span("toolbot_llm_call", model=self.model_name)
+        else:
+            llm_span = Span("toolbot_llm_call", model=self.model_name)
 
-        try:
-            if hasattr(final, "choices") and hasattr(final.choices, "__len__"):
-                choices_len = len(final.choices)
-                if choices_len > 0:
-                    message = final.choices[0].message
-                    tool_calls_attr = getattr(message, "tool_calls", None)
-                    content_attr = getattr(message, "content", None)
-                    logger.debug("Response message.tool_calls: {}", tool_calls_attr)
-                    logger.debug("Response message.content: {}", content_attr)
-        except (TypeError, AttributeError):
-            pass
+        with llm_span:
+            message_list, user_messages = self.compose_tool_messages(
+                *messages, execution_history=execution_history
+            )
 
-        tool_calls = extract_tool_calls(final)
+            stream = self.stream_target != "none"
+            logger.debug("Message list: {}", message_list)
+            response = await make_async_response(self, message_list, stream=stream)
+            final = await async_stream_chunks(self, response, target=self.stream_target)
+            logger.debug("Response: {}", final)
 
-        # Capture content for auto-route fallback (coding-agent termination).
-        try:
-            if hasattr(final, "choices") and final.choices:
-                self._last_content = getattr(final.choices[0].message, "content", None)
-            else:
+            try:
+                if hasattr(final, "choices") and hasattr(final.choices, "__len__"):
+                    choices_len = len(final.choices)
+                    if choices_len > 0:
+                        message = final.choices[0].message
+                        tool_calls_attr = getattr(message, "tool_calls", None)
+                        content_attr = getattr(message, "content", None)
+                        logger.debug("Response message.tool_calls: {}", tool_calls_attr)
+                        logger.debug("Response message.content: {}", content_attr)
+            except (TypeError, AttributeError):
+                pass
+
+            tool_calls = extract_tool_calls(final)
+
+            # Capture content for auto-route fallback (coding-agent termination).
+            try:
+                if hasattr(final, "choices") and final.choices:
+                    self._last_content = getattr(
+                        final.choices[0].message, "content", None
+                    )
+                else:
+                    self._last_content = None
+            except (TypeError, AttributeError):
                 self._last_content = None
-        except (TypeError, AttributeError):
-            self._last_content = None
 
-        try:
-            if (
-                tool_calls
-                and hasattr(final, "choices")
-                and hasattr(final.choices, "__len__")
-            ):
-                choices_len = len(final.choices)
-                if choices_len > 0:
-                    message = final.choices[0].message
-                    if message.tool_calls is None and message.content:
-                        logger.debug(
-                            "Parsed tool calls from JSON content for model {}: {}",
-                            self.model_name,
-                            [tc.function.name for tc in tool_calls],
-                        )
-        except (TypeError, AttributeError):
-            pass
+            try:
+                if (
+                    tool_calls
+                    and hasattr(final, "choices")
+                    and hasattr(final.choices, "__len__")
+                ):
+                    choices_len = len(final.choices)
+                    if choices_len > 0:
+                        message = final.choices[0].message
+                        if message.tool_calls is None and message.content:
+                            logger.debug(
+                                "Parsed tool calls from JSON content for model {}: {}",
+                                self.model_name,
+                                [tc.function.name for tc in tool_calls],
+                            )
+            except (TypeError, AttributeError):
+                pass
 
-        if user_messages:
-            self.chat_memory.append(user_messages[0])
-            self.chat_memory.append(AIMessage(content=str(tool_calls)))
+            if user_messages:
+                self.chat_memory.append(user_messages[0])
+                self.chat_memory.append(AIMessage(content=str(tool_calls)))
 
-        return tool_calls
+            llm_span["chosen_tools"] = str(
+                [tc.function.name for tc in tool_calls] if tool_calls else []
+            )
+            return tool_calls

--- a/llamabot/components/pocketflow/nodes.py
+++ b/llamabot/components/pocketflow/nodes.py
@@ -6,7 +6,7 @@ from typing import Callable, List, Optional
 from loguru import logger
 from pocketflow import Node
 
-from llamabot.recorder import Span, get_current_span, is_span_recording_enabled
+from llamabot.recorder import Span, get_current_span
 
 # Constant for the default loopback action name
 DECIDE_NODE_ACTION = "decide"
@@ -362,30 +362,24 @@ class DecideNode(Node):
         :raises ValueError: If no tool calls are returned from ToolBot or if JSON
                             parsing fails
         """
-        # Add span support for decision making
-        if is_span_recording_enabled():
-            current_span = get_current_span()
-            if current_span:
-                decision_span = current_span.span(
-                    "decision",
-                    iteration=prep_res.get("iteration_count", 0),
-                    model=self.model_name,
-                )
-                with decision_span:
-                    return self._exec_decision(prep_res, decision_span)
-            else:
-                # No parent span, create root span
-                trace_id = prep_res.get("trace_id")
-                decision_span = Span(
-                    "decision",
-                    trace_id=trace_id,
-                    iteration=prep_res.get("iteration_count", 0),
-                    model=self.model_name,
-                )
-                with decision_span:
-                    return self._exec_decision(prep_res, decision_span)
+        # Always create a decision span (matches @tool/@span behaviour).
+        current_span = get_current_span()
+        if current_span:
+            decision_span = current_span.span(
+                "decision",
+                iteration=prep_res.get("iteration_count", 0),
+                model=self.model_name,
+            )
         else:
-            return self._exec_decision(prep_res, None)
+            trace_id = prep_res.get("trace_id")
+            decision_span = Span(
+                "decision",
+                trace_id=trace_id,
+                iteration=prep_res.get("iteration_count", 0),
+                model=self.model_name,
+            )
+        with decision_span:
+            return self._exec_decision(prep_res, decision_span)
 
     def _exec_decision(self, prep_res, span_obj: Optional[Span]):
         """Internal method to execute decision logic.
@@ -705,26 +699,25 @@ class DecideNode(Node):
         :param prep_res: Output from :meth:`prep`.
         :return: Tool name for PocketFlow routing.
         """
-        if is_span_recording_enabled():
-            current_span = get_current_span()
-            if current_span:
-                decision_span = current_span.span(
-                    "decision",
-                    iteration=prep_res.get("iteration_count", 0),
-                    model=self.model_name,
-                )
-                with decision_span:
-                    return await self._exec_decision_async(prep_res, decision_span)
-            trace_id = prep_res.get("trace_id")
-            decision_span = Span(
+        # Always create a decision span (matches @tool/@span behaviour).
+        current_span = get_current_span()
+        if current_span:
+            decision_span = current_span.span(
                 "decision",
-                trace_id=trace_id,
                 iteration=prep_res.get("iteration_count", 0),
                 model=self.model_name,
             )
             with decision_span:
                 return await self._exec_decision_async(prep_res, decision_span)
-        return await self._exec_decision_async(prep_res, None)
+        trace_id = prep_res.get("trace_id")
+        decision_span = Span(
+            "decision",
+            trace_id=trace_id,
+            iteration=prep_res.get("iteration_count", 0),
+            model=self.model_name,
+        )
+        with decision_span:
+            return await self._exec_decision_async(prep_res, decision_span)
 
     def post(self, shared, prep_res, exec_res):
         """Post-process the execution result.

--- a/llamabot/recorder.py
+++ b/llamabot/recorder.py
@@ -1618,6 +1618,90 @@ def generate_span_html(
     # Generate pagination controls
     pagination_html = generate_pagination_html(page, total_pages, total_spans, per_page)
 
+    # Compute trace boundaries for waterfall positioning
+    valid_starts = [s.get("start_time") for s in sorted_spans if s.get("start_time")]
+    valid_ends = [s.get("end_time") for s in sorted_spans if s.get("end_time")]
+    from datetime import datetime as _dt
+
+    if valid_starts and valid_ends:
+        trace_start_dt = min(
+            _dt.fromisoformat(s.replace("Z", "+00:00")) for s in valid_starts
+        )
+        trace_end_dt = max(
+            _dt.fromisoformat(s.replace("Z", "+00:00")) for s in valid_ends
+        )
+        trace_duration_ms = max(
+            (trace_end_dt - trace_start_dt).total_seconds() * 1000, 0.001
+        )
+    else:
+        trace_start_dt = None
+        trace_duration_ms = 1.0
+
+    # Generate waterfall rows
+    waterfall_rows = []
+    for span in sorted_spans:
+        nesting = calculate_nesting_level(span, span_dict_lookup)
+        op_name = escape_html(span.get("operation_name", ""))
+        duration_ms = span.get("duration_ms") or 0
+        is_in_progress = (
+            span.get("status") == "started" and span.get("end_time") is None
+        )
+
+        # Compute bar position and width
+        if trace_start_dt and span.get("start_time"):
+            try:
+                span_start = _dt.fromisoformat(
+                    span["start_time"].replace("Z", "+00:00")
+                )
+                offset_pct = max(
+                    (span_start - trace_start_dt).total_seconds()
+                    * 1000
+                    / trace_duration_ms
+                    * 100,
+                    0,
+                )
+            except (ValueError, TypeError):
+                offset_pct = 0
+        else:
+            offset_pct = 0
+
+        width_pct = (
+            max(duration_ms / trace_duration_ms * 100, 0.3) if duration_ms else 0.3
+        )
+        width_pct = min(width_pct, 100 - offset_pct)
+
+        # Color by operation type
+        op = span.get("operation_name", "")
+        if "agentbot" in op or op == "agentbot_call":
+            bar_color = "#5E81AC"
+        elif op == "decision":
+            bar_color = "#88C0D0"
+        elif "llm" in op:
+            bar_color = "#D08770"
+        elif "toolbot" in op:
+            bar_color = "#B48EAD"
+        else:
+            bar_color = "#A3BE8C"
+
+        dur_str = format_duration(duration_ms, is_in_progress)
+        indent_px = nesting * 16
+
+        waterfall_rows.append(
+            f"""
+            <div class="wf-row" style="margin-left: {indent_px}px;"
+                 onclick="selectSpan('{escape_html(span["span_id"])}')">
+                <span class="wf-label">{op_name}</span>
+                <div class="wf-track">
+                    <div class="wf-bar" style="margin-left: {offset_pct:.1f}%; width: {width_pct:.1f}%; background: {bar_color};">
+                        <span class="wf-dur">{dur_str}</span>
+                    </div>
+                </div>
+            </div>
+            """
+        )
+
+    waterfall_html = "\n".join(waterfall_rows)
+
     # Complete HTML with embedded CSS and JavaScript
     html = f"""
     <style>
@@ -1773,8 +1857,88 @@ def generate_span_html(
                 background: #5E81AC;
                 color: white;
             }}
+            /* View toggle */
+            .view-toggle {{
+                display: flex;
+                gap: 0;
+                margin-bottom: 0.5rem;
+            }}
+            .view-toggle button {{
+                padding: 0.4rem 1rem;
+                border: 1px solid #D8DEE9;
+                background: #ECEFF4;
+                color: #2E3440;
+                cursor: pointer;
+                font-size: 0.9rem;
+            }}
+            .view-toggle button.active {{
+                background: #5E81AC;
+                color: white;
+                border-color: #5E81AC;
+            }}
+            .view-toggle button:first-child {{
+                border-radius: 4px 0 0 4px;
+            }}
+            .view-toggle button:last-child {{
+                border-radius: 0 4px 4px 0;
+                border-left: none;
+            }}
+            /* Waterfall chart */
+            .waterfall-view {{
+                background: white;
+                border-radius: 8px;
+                padding: 1rem;
+                overflow-x: auto;
+            }}
+            .wf-row {{
+                display: flex;
+                align-items: center;
+                height: 28px;
+                cursor: pointer;
+                border-radius: 3px;
+            }}
+            .wf-row:hover {{
+                background: #ECEFF4;
+            }}
+            .wf-label {{
+                width: 200px;
+                min-width: 200px;
+                font-size: 0.85rem;
+                color: #2E3440;
+                padding-right: 0.5rem;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }}
+            .wf-track {{
+                flex: 1;
+                height: 20px;
+                background: #ECEFF4;
+                border-radius: 3px;
+                position: relative;
+                min-width: 300px;
+            }}
+            .wf-bar {{
+                height: 100%;
+                border-radius: 3px;
+                display: flex;
+                align-items: center;
+                padding-left: 4px;
+                min-width: 2px;
+                overflow: hidden;
+            }}
+            .wf-dur {{
+                font-size: 0.75rem;
+                color: #2E3440;
+                font-weight: 600;
+                white-space: nowrap;
+            }}
         </style>
-        <div class="span-container">
+        <div class="view-toggle">
+            <button class="active" onclick="showView('timeline')">Timeline</button>
+            <button onclick="showView('waterfall')">Waterfall</button>
+        </div>
+        <div id="timeline-view" class="span-container">
             <div class="span-timeline">
                 <div class="span-list">
                     {"".join(span_items_html)}
@@ -1784,6 +1948,9 @@ def generate_span_html(
             <div class="span-details" id="span-details-panel">
                 {details_html}
             </div>
+        </div>
+        <div id="waterfall-view" class="waterfall-view" style="display:none">
+            {waterfall_html}
         </div>
         <script>
             // Embed span data for JavaScript access
@@ -1963,6 +2130,22 @@ def generate_span_html(
 
             // Initialize pagination on load
             renderSpans(currentPage);
+
+            function showView(view) {{
+                const timeline = document.getElementById('timeline-view');
+                const waterfall = document.getElementById('waterfall-view');
+                const buttons = document.querySelectorAll('.view-toggle button');
+                buttons.forEach(b => b.classList.remove('active'));
+                if (view === 'waterfall') {{
+                    timeline.style.display = 'none';
+                    waterfall.style.display = 'block';
+                    buttons[1].classList.add('active');
+                }} else {{
+                    timeline.style.display = 'grid';
+                    waterfall.style.display = 'none';
+                    buttons[0].classList.add('active');
+                }}
+            }}
         </script>
     </div>
     """

--- a/tests/bot/test_agentbot.py
+++ b/tests/bot/test_agentbot.py
@@ -920,3 +920,69 @@ def test_decide_node_raises_when_no_tool_calls_and_no_content():
 
         with pytest.raises(ValueError, match="No tool calls and no content"):
             decide_node.exec(prep_res)
+
+
+def test_decide_node_always_creates_decision_span():
+    """DecideNode.exec creates a span unconditionally (not gated behind flag)."""
+    from llamabot.components.pocketflow.nodes import DecideNode
+    from llamabot.recorder import Span
+
+    with patch("llamabot.bot.toolbot.ToolBot") as mock_toolbot_class:
+        mock_toolbot = MagicMock()
+        mock_tool_call = MagicMock()
+        mock_tool_call.function.name = "respond_to_user"
+        mock_tool_call.function.arguments = '{"response": "done"}'
+        mock_toolbot.return_value = [mock_tool_call]
+        mock_toolbot_class.return_value = mock_toolbot
+
+        decide_node = DecideNode(
+            tools=[], system_prompt="Pick tools.", model_name="gpt-4.1"
+        )
+
+        # Create a parent span (simulating AgentBot.__call__)
+        with Span("agentbot_call"):
+            prep_res = {"memory": ["test"], "globals_dict": {}, "iteration_count": 1}
+            result = decide_node.exec(prep_res)
+
+        assert result == "respond_to_user"
+
+
+def test_make_response_creates_llm_request_span():
+    """make_response wraps the litellm call in an llm_request span."""
+    from llamabot.bot.simplebot import make_response
+    from llamabot.recorder import Span
+
+    with (
+        patch("litellm.completion") as mock_completion,
+        patch("llamabot.bot.simplebot.completion_kwargs_for_messages") as mock_kwargs,
+    ):
+        mock_completion.return_value = MagicMock()
+        mock_kwargs.return_value = {"model": "test-model"}
+
+        bot = MagicMock()
+        bot.model_name = "test-model"
+
+        with Span("parent"):
+            make_response(bot, [], stream=False)
+
+        mock_completion.assert_called_once()
+
+
+def test_spanlist_waterfall_toggle_in_html():
+    """SpanList._repr_html_ includes both timeline and waterfall views with toggle."""
+    from llamabot.recorder import Span, SpanList
+
+    # Create a simple span tree
+    with Span("root_op") as root:
+        root["duration_ms"] = 1000
+        with root.span("child_op") as child:
+            pass
+
+    spans = SpanList([root, child])
+    html = spans._repr_html_()
+
+    # Both views should be present
+    assert "timeline-view" in html
+    assert "waterfall-view" in html
+    assert "showView" in html
+    assert "wf-bar" in html


### PR DESCRIPTION
## Problem

AgentBot showed ~120s total but only ~525ms accounted for (search_corpus + respond_to_user). The other ~119s — the LLM decision calls — were completely invisible.

## Root causes (3 gaps)

1. **BUG**: DecideNode.exec gated span creation behind is_span_recording_enabled() — a flag never set in production. No decision spans were ever created.

2. **GAP**: ToolBot.__call__ (sync + async) created zero spans. The tool-selection LLM call (~60s/iteration) was invisible.

3. **GAP**: make_response / make_async_response had no span around the litellm.completion() HTTP call.

## Fixes

| File | Change |
|------|--------|
| nodes.py | Removed is_span_recording_enabled() gate — always create decision span |
| toolbot.py | Wrapped ToolBot.__call__ + AsyncToolBot.__call__ in toolbot_llm_call span |
| simplebot.py | Wrapped make_response + make_async_response in llm_request span |
| recorder.py | Added waterfall chart view with toggle (timeline ↔ waterfall) |

## Span tree: before vs after

**Before:** only tool function spans were visible (via @span decorator)
```
agentbot_call  ~120s
├── search_corpus  525ms
└── respond_to_user  0ms
```

**After:** every step is instrumented
```
agentbot_call           ~120s
├── decision (iter 1)    ~60s
│   └── toolbot_llm_call  ~60s
│       └── llm_request   ~57s
├── search_corpus         525ms
├── decision (iter 2)    ~59s
│   └── toolbot_llm_call  ~59s
│       └── llm_request   ~56s
└── respond_to_user        0ms
```

## Waterfall chart

New toggle in SpanList._repr_html_ switches between:
- **Timeline** (existing two-panel view)
- **Waterfall** (horizontal bar chart: each span positioned by start time, sized by duration, color-coded by type, left/right scrollable)

## Tests

- 3 new tests: decision span always created, make_response span, waterfall HTML toggle
- All 37 existing agentbot tests pass
