### PR TITLE
fix: remove loguru default sink before adding llamabot sink

### DIFF
--- a/llamabot/__init__.py
+++ b/llamabot/__init__.py
@@ -47,7 +47,7 @@ level_map = {
     "CRITICAL": "CRITICAL",
 }
 
-logger.remove()
+logger.remove(0)
 logger.add(lambda msg: print(msg, end=""), level=level_map.get(log_level, "WARNING"))
 
 __getattr__, __dir__, __all__ = lazy_loader.attach(

--- a/llamabot/__init__.py
+++ b/llamabot/__init__.py
@@ -47,6 +47,9 @@ level_map = {
     "CRITICAL": "CRITICAL",
 }
 
+# Remove only loguru's pre-configured default sink (always id 0 per loguru docs),
+# leaving any sinks the application added before importing llamabot intact.
+# A bare logger.remove() would clobber those user-defined sinks.
 logger.remove(0)
 logger.add(lambda msg: print(msg, end=""), level=level_map.get(log_level, "WARNING"))
 

--- a/llamabot/__init__.py
+++ b/llamabot/__init__.py
@@ -47,6 +47,7 @@ level_map = {
     "CRITICAL": "CRITICAL",
 }
 
+logger.remove()
 logger.add(lambda msg: print(msg, end=""), level=level_map.get(log_level, "WARNING"))
 
 __getattr__, __dir__, __all__ = lazy_loader.attach(

--- a/tests/test_import_smoke.py
+++ b/tests/test_import_smoke.py
@@ -6,6 +6,9 @@ These tests verify that:
 3. No import-time crashes occur for optional extras
 """
 
+import json
+import subprocess
+import sys
 import time
 
 
@@ -148,6 +151,51 @@ def test_set_debug_mode():
     from llamabot import set_debug_mode
 
     assert callable(set_debug_mode)
+
+
+def test_import_removes_default_debug_sink():
+    """Importing llamabot must remove loguru's pre-configured DEBUG sink (id 0).
+
+    Regression test for issue #381: without ``logger.remove(0)`` at import
+    time, loguru's default DEBUG sink stays attached and DEBUG messages leak
+    to stderr regardless of ``LOG_LEVEL``.
+    """
+    script = (
+        "import os, json; "
+        'os.environ["LOG_LEVEL"] = "WARNING"; '
+        "from loguru import logger; "
+        "import llamabot; "
+        "print(json.dumps([h._levelno for h in logger._core.handlers.values()]))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+    levels = json.loads(result.stdout.strip())
+    assert 10 not in levels, f"DEBUG sink (level 10) should be removed: {levels}"
+    assert 30 in levels, f"WARNING sink (level 30) should be present: {levels}"
+
+
+def test_import_preserves_user_sinks():
+    """Importing llamabot must not clobber sinks added by the user before import.
+
+    Per Copilot review on PR #385: ``logger.remove()`` would remove ALL sinks;
+    ``logger.remove(0)`` targets only loguru's default pre-configured sink.
+    """
+    script = (
+        "import os, json; "
+        'os.environ["LOG_LEVEL"] = "WARNING"; '
+        "from loguru import logger; "
+        "logger.add(lambda msg: None, level='INFO'); "
+        "import llamabot; "
+        "print(json.dumps([h._levelno for h in logger._core.handlers.values()]))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+    levels = json.loads(result.stdout.strip())
+    assert 10 not in levels, f"DEBUG default sink should be removed: {levels}"
+    assert 20 in levels, f"User INFO sink (level 20) should survive import: {levels}"
+    assert 30 in levels, f"llamabot WARNING sink (level 30) should be present: {levels}"
 
 
 def test_all_exports_importable():


### PR DESCRIPTION
## Summary

Resolves #381.

Loguru ships a pre-configured DEBUG sink at index 0. llamabot's module-level `logger.add()` call added a second sink without first removing the default, so DEBUG messages were always emitted to stderr regardless of the `LOG_LEVEL` environment variable.

## Fix

Add `logger.remove()` before `logger.add(...)` at module import time in `llamabot/__init__.py`, mirroring what `set_debug_mode()` already does correctly.

## Verification

```python
import os
os.environ["LOG_LEVEL"] = "WARNING"
from loguru import logger
import llamabot

for h in logger._core.handlers.values():
    print(h._levelno)
# Before fix: prints both 10 (DEBUG) and 30 (WARNING)
# After fix:  prints only 30 (WARNING)
```

cc @copilot for review