### PR TITLE
fix: silence litellm "Provider List" banner for bare model names

### DIFF
--- a/llamabot/__init__.py
+++ b/llamabot/__init__.py
@@ -24,6 +24,14 @@ from loguru import logger
 
 import lazy_loader
 
+# Silence litellm's noisy "Provider List: ..." banner, printed whenever
+# get_llm_provider() cannot infer a provider from a bare model name (e.g. the
+# default "gpt-4.1"). The banner precedes a BadRequestError that callers
+# already handle, so it is pure noise. Must run before any litellm call.
+import litellm
+
+litellm.suppress_debug_info = True
+
 
 def set_debug_mode(enabled: bool = True) -> None:
     """Set debug mode for llamabot.


### PR DESCRIPTION
## Problem

Users see this noise repeated multiple times whenever llamabot touches a model without a provider prefix (the default model is `gpt-4.1`):

```
Provider List: https://docs.litellm.ai/docs/providers
Provider List: https://docs.litellm.ai/docs/providers
Provider List: https://docs.litellm.ai/docs/providers
Provider List: https://docs.litellm.ai/docs/providers
```

## Root cause

The message comes from **litellm** (`litellm_core_utils/get_llm_provider_logic.py:448`), not llamabot. It is printed whenever `get_llm_provider()` cannot infer a provider from a bare model name, and is guarded only by `litellm.suppress_debug_info is False` (litellm's default).

llamabot's default model `"gpt-4.1"` has no `openai/` prefix, so every litellm capability lookup (`supports_response_schema`, `get_supported_openai_params`, etc.) hits this path, prints the banner, then swallows the resulting `BadRequestError`. The 4 repeats = 4 such lookups during a typical bot construction.

## Fix

Set `litellm.suppress_debug_info = True` in `llamabot/__init__.py` right after `import litellm`, before any bot can be constructed.

## Verification

```python
import llamabot
from litellm import supports_response_schema
supports_response_schema(model='gpt-4.1')  # silent now; previously printed banner 4x
# -> True (still correct)
```

Pre-commit hooks all pass (black, ruff, pydoclint, interrogate).

To re-enable the banner for debugging an unknown model: `import litellm; litellm.suppress_debug_info = False`.