### PR TITLE
fix(cli): lazy-import uvicorn so llamabot[cli] loads without it

### DIFF
--- a/llamabot/cli/logviewer.py
+++ b/llamabot/cli/logviewer.py
@@ -2,7 +2,6 @@
 
 from typing import Optional
 import typer
-import uvicorn
 from pathlib import Path
 
 
@@ -23,6 +22,7 @@ def launch(
     """
     from llamabot.web.app import create_app
     from llamabot.prompt_manager import find_or_set_db_path
+    import uvicorn
 
     db_path = find_or_set_db_path(db_path)
 


### PR DESCRIPTION
## Summary

`llamabot[cli]` installs fail to import with `ModuleNotFoundError: No module named 'uvicorn'`, breaking any downstream consumer that installs only the `cli` extra.

## Root cause

`llamabot/cli/logviewer.py` did a top-level `import uvicorn`, but `uvicorn` is declared in the `web` extra, **not** `cli`:

| extra | includes `uvicorn`? |
|---|---|
| `cli` | no |
| `web` | yes |
| `all` | yes |

Since `cli/__init__.py` imports `logviewer` unconditionally, loading the CLI triggers the `uvicorn` import — which isn't present in a `llamabot[cli]`-only install. Reproducer (canvas-chat auto-release):

```
$ uv tool install llamabot[cli]
$ llamabot configure default-model --model-name=gpt-4.1-mini
Traceback (most recent call last):
  File ".../llamabot/cli/__init__.py", line 11, in <module>
    from . import (...)
  File ".../llamabot/cli/logviewer.py", line 5, in <module>
    import uvicorn
ModuleNotFoundError: No module named 'uvicorn'
```

## Solution

Move `import uvicorn` inside the `launch()` function, matching the existing lazy imports already there (`create_app`, `find_or_set_db_path`). The typer `app` still registers at module load, so CLI discovery is unaffected; `uvicorn` is only resolved when `llamabot log-viewer launch` actually runs — at which point the user is expected to have the `web` extra installed.

This respects the existing extras design (`web` = log viewer + FastAPI UI; `cli` = git helpers, rich output, etc.) rather than bloating `cli` with a web dependency.

## Changes

- `llamabot/cli/logviewer.py`: top-level `import uvicorn` → lazy import inside `launch()`.

## Verification

```python
# Module + full CLI now import with uvicorn absent
>>> import sys; sys.modules['uvicorn'] = None  # poison
>>> import llamabot.cli  # was: ModuleNotFoundError
>>> llamabot.cli.app  # typer app registers fine
<Typer object>
```

```
$ uv run --with pytest --with pytest-cov --with gitpython python -m pytest tests/test_cli.py -x -q --no-cov
1 passed
```

## Notes

- No new tests added — this is an import-time packaging fix; the repro above (poisoning `sys.modules['uvicorn']`) is the most direct proof and doesn't fit the existing pytest layout. Happy to add a regression test if maintainers prefer.
- Alternative considered: adding `uvicorn` to the `cli` extra. Rejected because `logviewer` is conceptually a `web` feature (the pyproject comment at the `web` extra explicitly says "FastAPI web UI and log viewer"), and the lazy-import approach already has precedent in this very function.
